### PR TITLE
[SELC-2434] - Add DELETED status for UserGroup, add status filter in UserGroupRestClient

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/groups/UserGroupStatus.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/groups/UserGroupStatus.java
@@ -1,5 +1,5 @@
 package it.pagopa.selfcare.dashboard.connector.model.groups;
 
 public enum UserGroupStatus {
-    ACTIVE, SUSPENDED;
+    ACTIVE, SUSPENDED, DELETED
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImpl.java
@@ -170,7 +170,11 @@ public class UserGroupConnectorImpl implements UserGroupConnector {
     public Page<UserGroupInfo> getUserGroups(UserGroupFilter filter, Pageable pageable) {
         log.trace("getUserGroups start");
         log.debug("getUserGroups institutionId = {}, productId = {}, userId = {}, pageable = {}", filter.getInstitutionId(), filter.getProductId(), filter.getUserId(), pageable);
-        final Page<UserGroupInfo> userGroups = restClient.getUserGroups(filter.getInstitutionId().orElse(null), filter.getProductId().orElse(null), filter.getUserId().orElse(null), pageable)
+        final Page<UserGroupInfo> userGroups = restClient.getUserGroups(filter.getInstitutionId().orElse(null),
+                        filter.getProductId().orElse(null),
+                        filter.getUserId().orElse(null),
+                        List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED),
+                        pageable)
                 .map(GROUP_RESPONSE_TO_GROUP_INFO);
         log.debug("getUserGroups result = {}", userGroups);
         log.trace("getUserGroups end");

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserGroupRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserGroupRestClient.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.rest.client;
 
+import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupStatus;
 import it.pagopa.selfcare.dashboard.connector.rest.model.user_group.CreateUserGroupRequestDto;
 import it.pagopa.selfcare.dashboard.connector.rest.model.user_group.UpdateUserGroupRequestDto;
 import it.pagopa.selfcare.dashboard.connector.rest.model.user_group.UserGroupResponse;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "${rest-client.user-groups.serviceCode}", url = "${rest-client.user-groups.base-url}")
@@ -59,5 +61,6 @@ public interface UserGroupRestClient {
     Page<UserGroupResponse> getUserGroups(@RequestParam(value = "institutionId", required = false) String institutionId,
                                           @RequestParam(value = "productId", required = false) String productId,
                                           @RequestParam(value = "userId", required = false) UUID memberId,
+                                          @RequestParam(value = "status", required = false) List<UserGroupStatus> status,
                                           Pageable pageable);
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImplTest.java
@@ -12,10 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 
 import java.time.Instant;
 import java.util.List;
@@ -370,7 +367,7 @@ class UserGroupConnectorImplTest {
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
         when(restClientMock.getUserGroups(anyString(), anyString(), any(), any(), any()))
-                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
+                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(4, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
@@ -398,7 +395,7 @@ class UserGroupConnectorImplTest {
         UserGroupFilter filter = new UserGroupFilter();
         Pageable pageable = Pageable.unpaged();
         when(restClientMock.getUserGroups(any(), any(), any(), any(), any()))
-                .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(3, Pageable.class), () -> 0L));
+                .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(4, Pageable.class), () -> 0L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
@@ -421,7 +418,7 @@ class UserGroupConnectorImplTest {
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
         when(restClientMock.getUserGroups(anyString(), anyString(), any(), any(), any()))
-                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
+                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(4, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
@@ -441,7 +438,7 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());
         assertEquals(response1.getModifiedBy(), groupInfo.getModifiedBy().getId());
         verify(restClientMock, times(1))
-                .getUserGroups(eq(institutionId.get()), eq(productId.get()), isNull(), isNull(), isNotNull());
+                .getUserGroups(eq(institutionId.get()), eq(productId.get()), isNull(), eq(List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED)), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -457,7 +454,7 @@ class UserGroupConnectorImplTest {
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
         when(restClientMock.getUserGroups(any(), any(), any(), anyList(), any()))
-                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
+                .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(4, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
@@ -477,7 +474,7 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());
         assertEquals(response1.getModifiedBy(), groupInfo.getModifiedBy().getId());
         verify(restClientMock, times(1))
-                .getUserGroups(isNull(), isNull(), eq(userId.get()), isNull(), isNotNull());
+                .getUserGroups(isNull(), isNull(), eq(userId.get()), eq(List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED)), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -488,14 +485,14 @@ class UserGroupConnectorImplTest {
         UserGroupFilter filter = new UserGroupFilter();
         Pageable pageable = Pageable.unpaged();
         when(restClientMock.getUserGroups(any(), any(), any(), any(), any()))
-                .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(3, Pageable.class), () -> 0L));
+                .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(4, Pageable.class), () -> 0L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
         assertNotNull(groupInfos);
         assertTrue(groupInfos.isEmpty());
         verify(restClientMock, times(1))
-                .getUserGroups(isNull(), isNull(), isNull(), isNull(), isNotNull());
+                .getUserGroups(isNull(), isNull(), isNull(),eq(List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED)), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -535,7 +532,6 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getStatus(), groupInfo.getStatus());
         assertEquals(response1.getDescription(), groupInfo.getDescription());
         assertEquals(response1.getName(), groupInfo.getName());
-        assertEquals(response1.getMembers(), groupInfo.getMembers());
         assertEquals(response1.getCreatedAt(), groupInfo.getCreatedAt());
         assertEquals(response1.getCreatedBy(), groupInfo.getCreatedBy().getId());
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserGroupConnectorImplTest.java
@@ -369,7 +369,7 @@ class UserGroupConnectorImplTest {
         response1.setMembers(List.of(randomUUID().toString(), randomUUID().toString()));
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
-        when(restClientMock.getUserGroups(anyString(), anyString(), any(), any()))
+        when(restClientMock.getUserGroups(anyString(), anyString(), any(), any(), any()))
                 .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
@@ -389,8 +389,6 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getCreatedBy(), groupInfo.getCreatedBy().getId());
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());
         assertEquals(response1.getModifiedBy(), groupInfo.getModifiedBy().getId());
-        verify(restClientMock, times(1))
-                .getUserGroups(anyString(), anyString(), any(), any());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -399,15 +397,13 @@ class UserGroupConnectorImplTest {
         //given
         UserGroupFilter filter = new UserGroupFilter();
         Pageable pageable = Pageable.unpaged();
-        when(restClientMock.getUserGroups(any(), any(), any(), any()))
+        when(restClientMock.getUserGroups(any(), any(), any(), any(), any()))
                 .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(3, Pageable.class), () -> 0L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
         //then
         assertNotNull(groupInfos);
         assertTrue(groupInfos.isEmpty());
-        verify(restClientMock, times(1))
-                .getUserGroups(isNull(), isNull(), isNull(), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -424,7 +420,7 @@ class UserGroupConnectorImplTest {
         response1.setMembers(List.of(randomUUID().toString(), randomUUID().toString()));
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
-        when(restClientMock.getUserGroups(anyString(), anyString(), any(), any()))
+        when(restClientMock.getUserGroups(anyString(), anyString(), any(), any(), any()))
                 .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
@@ -445,7 +441,7 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());
         assertEquals(response1.getModifiedBy(), groupInfo.getModifiedBy().getId());
         verify(restClientMock, times(1))
-                .getUserGroups(eq(institutionId.get()), eq(productId.get()), isNull(), isNotNull());
+                .getUserGroups(eq(institutionId.get()), eq(productId.get()), isNull(), isNull(), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -460,7 +456,7 @@ class UserGroupConnectorImplTest {
         response1.setMembers(List.of(randomUUID().toString(), randomUUID().toString()));
         response1.setCreatedAt(Instant.now());
         response1.setModifiedAt(Instant.now());
-        when(restClientMock.getUserGroups(any(), any(), any(), any()))
+        when(restClientMock.getUserGroups(any(), any(), any(), anyList(), any()))
                 .thenAnswer(invocation -> getPage(List.of(response1), invocation.getArgument(3, Pageable.class), () -> 1L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
@@ -481,7 +477,7 @@ class UserGroupConnectorImplTest {
         assertEquals(response1.getModifiedAt(), groupInfo.getModifiedAt());
         assertEquals(response1.getModifiedBy(), groupInfo.getModifiedBy().getId());
         verify(restClientMock, times(1))
-                .getUserGroups(isNull(), isNull(), eq(userId.get()), isNotNull());
+                .getUserGroups(isNull(), isNull(), eq(userId.get()), isNull(), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 
@@ -491,7 +487,7 @@ class UserGroupConnectorImplTest {
 
         UserGroupFilter filter = new UserGroupFilter();
         Pageable pageable = Pageable.unpaged();
-        when(restClientMock.getUserGroups(any(), any(), any(), any()))
+        when(restClientMock.getUserGroups(any(), any(), any(), any(), any()))
                 .thenAnswer(invocation -> getPage(emptyList(), invocation.getArgument(3, Pageable.class), () -> 0L));
         //when
         Page<UserGroupInfo> groupInfos = groupConnector.getUserGroups(filter, pageable);
@@ -499,7 +495,7 @@ class UserGroupConnectorImplTest {
         assertNotNull(groupInfos);
         assertTrue(groupInfos.isEmpty());
         verify(restClientMock, times(1))
-                .getUserGroups(isNull(), isNull(), isNull(), isNotNull());
+                .getUserGroups(isNull(), isNull(), isNull(), isNull(), isNotNull());
         verifyNoMoreInteractions(restClientMock);
     }
 

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserGroupRestClientTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserGroupRestClientTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import it.pagopa.selfcare.commons.connector.rest.BaseFeignRestClientTest;
 import it.pagopa.selfcare.commons.connector.rest.RestTestUtils;
 import it.pagopa.selfcare.commons.utils.TestUtils;
+import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupStatus;
 import it.pagopa.selfcare.dashboard.connector.rest.config.UserGroupRestClientTestConfig;
 import it.pagopa.selfcare.dashboard.connector.rest.model.user_group.CreateUserGroupRequestDto;
 import it.pagopa.selfcare.dashboard.connector.rest.model.user_group.UpdateUserGroupRequestDto;
@@ -201,7 +202,7 @@ class UserGroupRestClientTest extends BaseFeignRestClientTest {
         UUID userId = null;
         Pageable pageable = Pageable.unpaged();
         // when
-        Page<UserGroupResponse> response = restClient.getUserGroups(institutionId, productId, userId, pageable);
+        Page<UserGroupResponse> response = restClient.getUserGroups(institutionId, productId, userId, List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED), pageable);
         //then
         assertNotNull(response);
         assertEquals(0, response.getNumber());
@@ -229,7 +230,7 @@ class UserGroupRestClientTest extends BaseFeignRestClientTest {
         UUID userId = null;
         Pageable pageable = PageRequest.of(0, 1, Sort.by("name"));
         // when
-        Page<UserGroupResponse> response = restClient.getUserGroups(institutionId, productId, userId, pageable);
+        Page<UserGroupResponse> response = restClient.getUserGroups(institutionId, productId, userId, List.of(UserGroupStatus.ACTIVE, UserGroupStatus.SUSPENDED), pageable);
         //then
         assertNotNull(response);
         assertEquals(0, response.getNumber());


### PR DESCRIPTION
**List of Changes**

    1. add DELETED status for userGroup
    2. add status filter in UserGroupRestClient for Api getUserGroups
    3. call getUserGroups with status ACTIVE, SUSPENDED

**Motivation and Context**
Logical rather than physical deletion of UserGroups

**How Has This Been Tested?**

    1. Try to delete userGroup by its ID
    2. Check its status from getById
    3. Try to call getUserGroups (api have to returns only group with status ACTIVE or SUSPENDED)

