### PR TITLE
fix: Add MERGE_FUNCTION during retrieve institution's products

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import java.util.*;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,7 +58,7 @@ class InstitutionServiceImpl implements InstitutionService {
     private final ProductsConnector productsConnector;
     private final NotificationService notificationService;
 
-
+    protected static final BinaryOperator<PartyProduct> MERGE_FUNCTION = (inst1, inst2) -> inst1.getOnBoardingStatus().compareTo(inst2.getOnBoardingStatus()) < 0 ? inst1 : inst2;
 
     @Autowired
     public InstitutionServiceImpl(@Value("${dashboard.institution.getUsers.filter.states}") String[] allowedStates,
@@ -135,7 +136,7 @@ class InstitutionServiceImpl implements InstitutionService {
             if (selcAuthority.isPresent()) {
                 Map<String, ProductGrantedAuthority> userAuthProducts = ((SelfCareGrantedAuthority) selcAuthority.get()).getRoleOnProducts();
                 Map<String, PartyProduct> institutionsProductsMap = msCoreConnector.getInstitutionProducts(institutionId).stream()
-                        .collect(Collectors.toMap(PartyProduct::getId, Function.identity()));
+                        .collect(Collectors.toMap(PartyProduct::getId, Function.identity(), MERGE_FUNCTION));
 
                 if (LIMITED.name().equals(selcAuthority.get().getAuthority())) {
                     productTrees = productTrees.stream()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. add MERGE_FUNCTION during retrieve institution's products

#### Motivation and Context

Entity (PA) with multiple subscriptions in progress for the same product cannot access the dashboard

#### How Has This Been Tested?

1. Try to login in dashboard
2. Check its happened without error

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.