### PR TITLE
Selc 2550 refactor sulle resource per be dashboard

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2789,7 +2789,6 @@
       },
       "BackOfficeConfigurationsResource" : {
         "title" : "BackOfficeConfigurationsResource",
-        "required" : [ "environment", "url" ],
         "type" : "object",
         "properties" : {
           "environment" : {
@@ -2804,7 +2803,6 @@
       },
       "CertifiedFieldResourceOfstring" : {
         "title" : "CertifiedFieldResourceOfstring",
-        "required" : [ "certified", "value" ],
         "type" : "object",
         "properties" : {
           "certified" : {
@@ -2949,7 +2947,6 @@
       },
       "GeographicTaxonomyResource" : {
         "title" : "GeographicTaxonomyResource",
-        "required" : [ "code", "desc" ],
         "type" : "object",
         "properties" : {
           "code" : {
@@ -3050,9 +3047,7 @@
           },
           "mailAddress" : {
             "type" : "string",
-            "description" : "Institution's email address",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "Institution's email address"
           },
           "name" : {
             "type" : "string",
@@ -3078,12 +3073,15 @@
       },
       "InstitutionResource" : {
         "title" : "InstitutionResource",
-        "required" : [ "externalId", "fiscalCode", "geographicTaxonomies", "id", "mailAddress", "name", "origin", "originId", "status", "userRole" ],
         "type" : "object",
         "properties" : {
           "address" : {
             "type" : "string",
             "description" : "Institution's physical address"
+          },
+          "aooParentCode" : {
+            "type" : "string",
+            "description" : "UO's parent AOO code"
           },
           "category" : {
             "type" : "string",
@@ -3137,6 +3135,14 @@
             "type" : "string",
             "description" : "Institution's status"
           },
+          "subunitCode" : {
+            "type" : "string",
+            "description" : "AOO o UO unique code"
+          },
+          "subunitType" : {
+            "type" : "string",
+            "description" : "Institution's subunit type"
+          },
           "supportContact" : {
             "description" : "'Institution's assistance contacts'",
             "$ref" : "#/components/schemas/SupportContactResource"
@@ -3162,14 +3168,11 @@
       },
       "InstitutionUserDetailsResource" : {
         "title" : "InstitutionUserDetailsResource",
-        "required" : [ "fiscalCode", "id", "name", "products", "role", "status", "surname" ],
         "type" : "object",
         "properties" : {
           "email" : {
             "type" : "string",
-            "description" : "User's personal email",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "User's personal email"
           },
           "fiscalCode" : {
             "type" : "string",
@@ -3208,14 +3211,11 @@
       },
       "InstitutionUserResource" : {
         "title" : "InstitutionUserResource",
-        "required" : [ "id", "name", "products", "role", "status", "surname" ],
         "type" : "object",
         "properties" : {
           "email" : {
             "type" : "string",
-            "description" : "User's personal email",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "User's personal email"
           },
           "id" : {
             "type" : "string",
@@ -3339,7 +3339,6 @@
       },
       "PlainUserResource" : {
         "title" : "PlainUserResource",
-        "required" : [ "id", "name", "surname" ],
         "type" : "object",
         "properties" : {
           "id" : {
@@ -3359,7 +3358,6 @@
       },
       "PnPGInstitutionResource" : {
         "title" : "PnPGInstitutionResource",
-        "required" : [ "externalId", "fiscalCode", "id", "status" ],
         "type" : "object",
         "properties" : {
           "address" : {
@@ -3466,7 +3464,6 @@
       },
       "ProductInfoResource" : {
         "title" : "ProductInfoResource",
-        "required" : [ "id", "roleInfos" ],
         "type" : "object",
         "properties" : {
           "id" : {
@@ -3488,7 +3485,6 @@
       },
       "ProductRoleInfoResource" : {
         "title" : "ProductRoleInfoResource",
-        "required" : [ "relationshipId", "role", "selcRole", "status" ],
         "type" : "object",
         "properties" : {
           "relationshipId" : {
@@ -3512,7 +3508,6 @@
       },
       "ProductRoleMappingsResource" : {
         "title" : "ProductRoleMappingsResource",
-        "required" : [ "multiroleAllowed", "partyRole", "productRoles", "selcRole" ],
         "type" : "object",
         "properties" : {
           "multiroleAllowed" : {
@@ -3541,7 +3536,6 @@
       },
       "ProductRoleResource" : {
         "title" : "ProductRoleResource",
-        "required" : [ "code", "description", "label" ],
         "type" : "object",
         "properties" : {
           "code" : {
@@ -3560,14 +3554,11 @@
       },
       "ProductUserResource" : {
         "title" : "ProductUserResource",
-        "required" : [ "id", "name", "product", "role", "status", "surname" ],
         "type" : "object",
         "properties" : {
           "email" : {
             "type" : "string",
-            "description" : "User's personal email",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "User's personal email"
           },
           "id" : {
             "type" : "string",
@@ -3599,7 +3590,6 @@
       },
       "ProductsResource" : {
         "title" : "ProductsResource",
-        "required" : [ "authorized", "description", "id", "imageUrl", "logo", "productOnBoardingStatus", "status", "title", "urlBO" ],
         "type" : "object",
         "properties" : {
           "activatedAt" : {
@@ -3643,7 +3633,6 @@
             "description" : "Product's logo"
           },
           "logoBgColor" : {
-            "pattern" : "^#[0-9A-F]{6}$",
             "type" : "string",
             "description" : "Product logo's background color"
           },
@@ -3716,7 +3705,6 @@
       },
       "SubProductResource" : {
         "title" : "SubProductResource",
-        "required" : [ "id", "productOnBoardingStatus", "status", "title" ],
         "type" : "object",
         "properties" : {
           "description" : {
@@ -3736,7 +3724,6 @@
             "description" : "Product's logo"
           },
           "logoBgColor" : {
-            "pattern" : "^#[0-9A-F]{6}$",
             "type" : "string",
             "description" : "Product logo's background color"
           },
@@ -3921,7 +3908,7 @@
           "status" : {
             "type" : "string",
             "description" : "Users group's status",
-            "enum" : [ "ACTIVE", "SUSPENDED" ]
+            "enum" : [ "ACTIVE", "DELETED", "SUSPENDED" ]
           }
         }
       },
@@ -3978,13 +3965,12 @@
           "status" : {
             "type" : "string",
             "description" : "Users group's status",
-            "enum" : [ "ACTIVE", "SUSPENDED" ]
+            "enum" : [ "ACTIVE", "DELETED", "SUSPENDED" ]
           }
         }
       },
       "UserIdResource" : {
         "title" : "UserIdResource",
-        "required" : [ "id" ],
         "type" : "object",
         "properties" : {
           "id" : {
@@ -4001,9 +3987,7 @@
         "properties" : {
           "email" : {
             "type" : "string",
-            "description" : "User's institutional email",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "User's institutional email"
           },
           "fiscalCode" : {
             "type" : "string",
@@ -4039,7 +4023,6 @@
       },
       "UserResource" : {
         "title" : "UserResource",
-        "required" : [ "fiscalCode", "id" ],
         "type" : "object",
         "properties" : {
           "email" : {

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -3857,7 +3857,6 @@
       },
       "UserGroupPlainResource" : {
         "title" : "UserGroupPlainResource",
-        "required" : [ "description", "id", "institutionId", "membersCount", "name", "productId", "status" ],
         "type" : "object",
         "properties" : {
           "createdAt" : {
@@ -3914,7 +3913,6 @@
       },
       "UserGroupResource" : {
         "title" : "UserGroupResource",
-        "required" : [ "description", "id", "institutionId", "members", "name", "productId", "status" ],
         "type" : "object",
         "properties" : {
           "createdAt" : {

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/GeographicTaxonomyResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/GeographicTaxonomyResource.java
@@ -1,21 +1,13 @@
 package it.pagopa.selfcare.dashboard.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-
 @Data
 public class GeographicTaxonomyResource {
-    @ApiModelProperty(value = "${swagger.dashboard.geographicTaxonomy.model.code}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.geographicTaxonomy.model.code}")
     private String code;
 
-    @ApiModelProperty(value = "${swagger.dashboard.geographicTaxonomy.model.desc}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.geographicTaxonomy.model.desc}")
     private String desc;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionResource.java
@@ -1,66 +1,45 @@
 package it.pagopa.selfcare.dashboard.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionType;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class InstitutionResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.externalId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.externalId}")
     private String externalId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.originId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.originId}")
     private String originId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.origin}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.origin}")
     private String origin;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.institutionType}")
     private InstitutionType institutionType;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.name}")
     private String name;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.category}")
     private String category;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.fiscalCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.fiscalCode}")
     private String fiscalCode;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.mailAddress}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.mailAddress}")
     private String mailAddress;
 
-    @ApiModelProperty(value = "${swagger.dashboard.model.userRole}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.model.userRole}")
     private String userRole;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.status}")
     private String status;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.address}")
@@ -72,9 +51,7 @@ public class InstitutionResource {
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.recipientCode}")
     private String recipientCode;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.geographicTaxonomy}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.geographicTaxonomy}")
     private List<GeographicTaxonomyResource> geographicTaxonomies;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.vatNumberGroup}")

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionUserDetailsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionUserDetailsResource.java
@@ -12,18 +12,13 @@
 
 package it.pagopa.selfcare.dashboard.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class InstitutionUserDetailsResource extends InstitutionUserResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}")
     private String fiscalCode;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionUserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionUserResource.java
@@ -12,55 +12,36 @@
 
 package it.pagopa.selfcare.dashboard.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import it.pagopa.selfcare.dashboard.web.model.product.ProductInfoResource;
 import lombok.Data;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 @Data
 public class InstitutionUserResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}")
     private UUID id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}")
     private String name;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}")
     private String surname;
 
     @ApiModelProperty(value = "${swagger.dashboard.user.model.email}")
-    @Email
     private String email;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}")
     private SelfCareAuthority role;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}")
     private String status;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.products}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
-    @Valid
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.products}")
     private List<ProductInfoResource> products;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/PnPGInstitutionResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/PnPGInstitutionResource.java
@@ -1,23 +1,17 @@
 package it.pagopa.selfcare.dashboard.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 @Data
 public class PnPGInstitutionResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.externalId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.externalId}")
     private String externalId;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.originId}")
@@ -35,9 +29,7 @@ public class PnPGInstitutionResource {
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.category}")
     private String category;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.fiscalCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.fiscalCode}")
     private String fiscalCode;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.mailAddress}")
@@ -46,9 +38,7 @@ public class PnPGInstitutionResource {
     @ApiModelProperty(value = "${swagger.dashboard.model.userRole}")
     private String userRole;
 
-    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.institutions.model.status}")
     private String status;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.address}")

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/onboarding/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/onboarding/OnboardingRequestResource.java
@@ -6,10 +6,8 @@ import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,23 +17,17 @@ public class OnboardingRequestResource {
 
     @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.status}", required = true)
     @JsonProperty(required = true)
-    @NotNull
     private OnboardingStatus status;
 
     @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.institutionInfo}", required = true)
     @JsonProperty(required = true)
-    @NotNull
-    @Valid
     private InstitutionInfo institutionInfo;
 
     @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.manager}", required = true)
     @JsonProperty(required = true)
-    @NotNull
-    @Valid
     private UserInfo manager;
 
     @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.admins}")
-    @Valid
     private List<UserInfo> admins;
 
 
@@ -45,56 +37,44 @@ public class OnboardingRequestResource {
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.id}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String id;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.name}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String name;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.institutionType}", required = true)
         @JsonProperty(required = true)
-        @NotNull
         private InstitutionType institutionType;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.address}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String address;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.zipCode}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String zipCode;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.mailAddress}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
-        @Email
         private String mailAddress;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.fiscalCode}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String fiscalCode;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.vatNumber}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String vatNumber;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.recipientCode}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String recipientCode;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData}")
-        @Valid
         private PspData pspData;
 
         @ApiModelProperty(value = "${swagger.dashboard.institutions.model.dpoData}")
-        @Valid
         private DpoData dpoData;
 
         @Data
@@ -102,27 +82,22 @@ public class OnboardingRequestResource {
 
             @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.businessRegisterNumber}", required = true)
             @JsonProperty(required = true)
-            @NotBlank
             private String businessRegisterNumber;
 
             @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.legalRegisterName}", required = true)
             @JsonProperty(required = true)
-            @NotBlank
             private String legalRegisterName;
 
             @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.legalRegisterNumber}", required = true)
             @JsonProperty(required = true)
-            @NotBlank
             private String legalRegisterNumber;
 
             @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.abiCode}", required = true)
             @JsonProperty(required = true)
-            @NotBlank
             private String abiCode;
 
             @ApiModelProperty(value = "${swagger.dashboard.institutions.model.pspData.vatNumberGroup}", required = true)
             @JsonProperty(required = true)
-            @NotNull
             private Boolean vatNumberGroup;
         }
 
@@ -154,28 +129,22 @@ public class OnboardingRequestResource {
 
         @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
         @JsonProperty(required = true)
-        @NotNull
         private UUID id;
 
         @ApiModelProperty(value = "${swagger.dashboard.user.model.name}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String name;
 
         @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String surname;
 
         @ApiModelProperty(value = "${swagger.dashboard.user.model.institutionalEmail}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
-        @Email
         private String email;
 
         @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}", required = true)
         @JsonProperty(required = true)
-        @NotBlank
         private String fiscalCode;
 
     }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/BackOfficeConfigurationsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/BackOfficeConfigurationsResource.java
@@ -1,22 +1,15 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class BackOfficeConfigurationsResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.product-backoffice-configurations.model.environment}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.product-backoffice-configurations.model.environment}")
     private String environment;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.urlBO}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.urlBO}")
     private String url;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductInfoResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductInfoResource.java
@@ -1,27 +1,18 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class ProductInfoResource {
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}")
     private String id;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.title}")
     private String title;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.roleInfos}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
-    @Valid
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.roleInfos}")
     private List<ProductRoleInfoResource> roleInfos;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleInfoResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleInfoResource.java
@@ -1,30 +1,19 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 @Data
 public class ProductRoleInfoResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.relationshipId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.relationshipId}")
     private String relationshipId;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.productRole}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.productRole}")
     private String role;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}")
     private String status;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}")
     private SelfCareAuthority selcRole;
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleMappingsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleMappingsResource.java
@@ -1,38 +1,26 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class ProductRoleMappingsResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.partyRole}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.partyRole}")
     private PartyRole partyRole;
 
-    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.selcRole}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.selcRole}")
     private SelfCareAuthority selcRole;
 
-    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.multiroleAllowed}", required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.multiroleAllowed}")
     private boolean multiroleAllowed;
 
-    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.productRoles}", required = true)
-    @JsonProperty(required = true)
-    @NotEmpty
-    @Valid
+    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.productRoles}")
     private List<ProductRoleResource> productRoles;
 
 
@@ -40,20 +28,15 @@ public class ProductRoleMappingsResource {
     @EqualsAndHashCode(of = "code")
     public static class ProductRoleResource {
 
-        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.code}", required = true)
-        @JsonProperty(required = true)
-        @NotBlank
+        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.code}")
         private String code;
 
-        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.label}", required = true)
-        @JsonProperty(required = true)
-        @NotBlank
+        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.label}")
         private String label;
 
-        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.description}", required = true)
-        @JsonProperty(required = true)
-        @NotBlank
+        @ApiModelProperty(value = "${swagger.dashboard.product-role.model.description}")
         private String description;
+        
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
@@ -12,53 +12,34 @@
 
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import lombok.Data;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class ProductUserResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}")
     private UUID id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}")
     private String name;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}")
     private String surname;
 
     @ApiModelProperty(value = "${swagger.dashboard.user.model.email}")
-    @Email
     private String email;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}")
     private SelfCareAuthority role;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.product}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
-    @Valid
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.product}")
     private ProductInfoResource product;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.status}")
     private String status;
 
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductsResource.java
@@ -1,83 +1,59 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductOnBoardingStatus;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductStatus;
 import lombok.Data;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 
 @Data
 public class ProductsResource {
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.logo}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.logo}")
     private String logo;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.logoBgColor}")
-    @Pattern(regexp = "^#[0-9A-F]{6}$")
     private String logoBgColor;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.imageUrl}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.imageUrl}")
     private String imageUrl;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.title}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.title}")
     private String title;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.description}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.description}")
     private String description;
 
     @ApiModelProperty("${swagger.dashboard.products.model.urlPublic}")
     private String urlPublic;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.urlBO}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.urlBO}")
     private String urlBO;
 
     @ApiModelProperty("${swagger.dashboard.products.model.activatedAt}")
     private OffsetDateTime activatedAt;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.authorized}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.authorized}")
     private boolean authorized;
 
     @ApiModelProperty(value = "${swagger.dashboard.model.userRole}")
     private String userRole;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.productOnBoardingStatus}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.productOnBoardingStatus}")
     private ProductOnBoardingStatus productOnBoardingStatus;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.status}")
     private ProductStatus status;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.children}")
     private List<SubProductResource> children;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.backOfficeEnvironmentConfigurations}")
-    @Valid
     private Collection<BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/SubProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/SubProductResource.java
@@ -1,36 +1,23 @@
 package it.pagopa.selfcare.dashboard.web.model.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductOnBoardingStatus;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductStatus;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-
 @Data
 public class SubProductResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.title}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.title}")
     private String title;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.productOnBoardingStatus}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.productOnBoardingStatus}")
     private ProductOnBoardingStatus productOnBoardingStatus;
 
-    @ApiModelProperty(value = "${swagger.dashboard.products.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.products.model.status}")
     private ProductStatus status;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.imageUrl}")
@@ -40,7 +27,6 @@ public class SubProductResource {
     private String logo;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.logoBgColor}")
-    @Pattern(regexp = "^#[0-9A-F]{6}$")
     private String logoBgColor;
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.description}")
@@ -48,4 +34,5 @@ public class SubProductResource {
 
     @ApiModelProperty(value = "${swagger.dashboard.products.model.urlPublic}")
     private String urlPublic;
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/CertifiedFieldResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/CertifiedFieldResource.java
@@ -4,18 +4,14 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-
 @Data
 @NoArgsConstructor
 public class CertifiedFieldResource<T> {
 
-    @ApiModelProperty(value = "${swagger.model.certifiedField.certified}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.model.certifiedField.certified}")
     private boolean certified;
 
-    @ApiModelProperty(value = "${swagger.model.certifiedField.value}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.model.certifiedField.value}")
     private T value;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserIdResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserIdResource.java
@@ -3,13 +3,11 @@ package it.pagopa.selfcare.dashboard.web.model.user;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class UserIdResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}")
     private UUID id;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserProductRoles.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserProductRoles.java
@@ -2,11 +2,9 @@ package it.pagopa.selfcare.dashboard.web.model.user;
 
 import lombok.Data;
 
-import javax.validation.constraints.NotEmpty;
 import java.util.Set;
 
 @Data
 public class UserProductRoles {
-    @NotEmpty
     Set<String> productRoles;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserProductRoles.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserProductRoles.java
@@ -2,9 +2,11 @@ package it.pagopa.selfcare.dashboard.web.model.user;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.Set;
 
 @Data
 public class UserProductRoles {
+    @NotEmpty
     Set<String> productRoles;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user/UserResource.java
@@ -1,18 +1,14 @@
 package it.pagopa.selfcare.dashboard.web.model.user;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class UserResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}")
     private UUID id;
 
     @ApiModelProperty(value = "${swagger.dashboard.user.model.name}")
@@ -24,8 +20,7 @@ public class UserResource {
     @ApiModelProperty(value = "${swagger.dashboard.user.model.institutionalEmail}")
     private CertifiedFieldResource<String> email;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}")
     private String fiscalCode;
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/PlainUserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/PlainUserResource.java
@@ -1,27 +1,18 @@
 package it.pagopa.selfcare.dashboard.web.model.user_groups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class PlainUserResource {
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.id}")
     private UUID id;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.name}")
     private String name;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}")
     private String surname;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupIdResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupIdResource.java
@@ -1,16 +1,11 @@
 package it.pagopa.selfcare.dashboard.web.model.user_groups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class UserGroupIdResource {
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
     private String id;
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupPlainResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupPlainResource.java
@@ -1,67 +1,45 @@
 package it.pagopa.selfcare.dashboard.web.model.user_groups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupStatus;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 
 @Data
 public class UserGroupPlainResource {
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.institutionId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.institutionId}")
     private String institutionId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.productId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.productId}")
     private String productId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.name}")
     private String name;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.description}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.description}")
     private String description;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.status}")
     private UserGroupStatus status;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.membersCount}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.membersCount}")
     private Integer membersCount;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.createdAt}")
-    @JsonProperty
     private Instant createdAt;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.createdBy}")
-    @JsonProperty
     private UUID createdBy;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.modifiedAt}")
-    @JsonProperty
     private Instant modifiedAt;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.modifiedBy}")
-    @JsonProperty
     private UUID modifiedBy;
-
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupResource.java
@@ -6,8 +6,6 @@ import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupStatus;
 import it.pagopa.selfcare.dashboard.web.model.product.ProductUserResource;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 
@@ -15,32 +13,26 @@ import java.util.List;
 public class UserGroupResource {
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}", required = true)
     @JsonProperty(required = true)
-    @NotBlank
     private String id;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.institutionId}", required = true)
     @JsonProperty(required = true)
-    @NotBlank
     private String institutionId;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.productId}", required = true)
     @JsonProperty(required = true)
-    @NotBlank
     private String productId;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.name}", required = true)
     @JsonProperty(required = true)
-    @NotBlank
     private String name;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.description}", required = true)
     @JsonProperty(required = true)
-    @NotBlank
     private String description;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.status}", required = true)
     @JsonProperty(required = true)
-    @NotNull
     private UserGroupStatus status;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.members}", required = true)
@@ -62,6 +54,5 @@ public class UserGroupResource {
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.modifiedBy}")
     @JsonProperty
     private PlainUserResource modifiedBy;
-
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/user_groups/UserGroupResource.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.dashboard.web.model.user_groups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupStatus;
 import it.pagopa.selfcare.dashboard.web.model.product.ProductUserResource;
@@ -11,48 +10,37 @@ import java.util.List;
 
 @Data
 public class UserGroupResource {
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.institutionId}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.institutionId}")
     private String institutionId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.productId}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.productId}")
     private String productId;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.name}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.name}")
     private String name;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.description}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.description}")
     private String description;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.status}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.status}")
     private UserGroupStatus status;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.members}", required = true)
-    @JsonProperty()
+    @ApiModelProperty(value = "${swagger.dashboard.user-group.model.members}")
     private List<ProductUserResource> members;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.createdAt}")
-    @JsonProperty
     private Instant createdAt;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.createdBy}")
-    @JsonProperty
     private PlainUserResource createdBy;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.modifiedAt}")
-    @JsonProperty
     private Instant modifiedAt;
 
     @ApiModelProperty(value = "${swagger.dashboard.user-group.model.modifiedBy}")
-    @JsonProperty
     private PlainUserResource modifiedBy;
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/ProductsResourceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/ProductsResourceTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProductsResourceTest {
@@ -62,16 +61,6 @@ class ProductsResourceTest {
                 })
                 .collect(Collectors.toList());
         assertTrue(filteredViolations.isEmpty());
-    }
-
-    @Test
-    void validateRegExViolation() {
-        //given
-        ProductsResource productsResource = TestUtils.mockInstance(new ProductsResource());
-        //when
-        Set<ConstraintViolation<Object>> violations = validator.validate(productsResource);
-        // then
-        assertFalse(violations.isEmpty());
     }
 
     @Test

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/product/SubProductResourceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/product/SubProductResourceTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SubProductResourceTest {
@@ -51,16 +50,6 @@ class SubProductResourceTest {
                 })
                 .collect(Collectors.toList());
         assertTrue(filteredViolations.isEmpty());
-    }
-
-    @Test
-    void validateRegExViolation() {
-        //given
-        SubProductResource subProductResource = TestUtils.mockInstance(new SubProductResource());
-        //when
-        Set<ConstraintViolation<Object>> violations = validator.validate(subProductResource);
-        // then
-        assertFalse(violations.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
#### List of Changes

Removed validation constraints on resources

#### Motivation and Context

It's not necessary to validate output objects; checks are available only for incoming dtos.

#### How Has This Been Tested?

Precondition: developments for ms-product and ms-user-group were already merged into release-dev branch.

I have run pipeline for this feature branch in order to have in dev environment these developments. In addition to this, I have changed document for collection **products**, making empty the field **title** for prod-io product, and document for collection **userGroups** making empty the field **name**. Then, I haved logged into selfcare application and checked that api calls for products and user-groups were in success.
For this test, I used the following credentials:

- test/test
- Comune di Brunello
- Comune di Gaeta


