### PR TITLE
Refactor on tokenExchange api organization claim  #feature/SELC-2514

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
@@ -29,6 +29,7 @@ public class InstitutionInfo {
     private String subunitCode;
     private String subunitType;
     private String aooParentCode;
+    private String parentDescription;
 
     @Override
     public boolean equals(Object o) {

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
@@ -5,7 +5,10 @@ import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.dashboard.connector.api.PartyConnector;
 import it.pagopa.selfcare.dashboard.connector.model.auth.AuthInfo;
 import it.pagopa.selfcare.dashboard.connector.model.auth.ProductRole;
-import it.pagopa.selfcare.dashboard.connector.model.institution.*;
+import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomy;
+import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomyList;
+import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
+import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.product.PartyProduct;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductOnBoardingStatus;
 import it.pagopa.selfcare.dashboard.connector.model.user.CreateUserDto;
@@ -75,11 +78,10 @@ class PartyConnectorImpl implements PartyConnector {
         }
         institutionInfo.setSupportContact(onboardingData.getSupportContact());
         institutionInfo.setPaymentServiceProvider(onboardingData.getPaymentServiceProvider());
-
         institutionInfo.setSubunitCode(onboardingData.getSubunitCode());
         institutionInfo.setSubunitType(onboardingData.getSubunitType());
         institutionInfo.setAooParentCode(onboardingData.getAooParentCode());
-
+        institutionInfo.setParentDescription(onboardingData.getParentDescription());
         return institutionInfo;
     };
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingData.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingData.java
@@ -33,5 +33,6 @@ public class OnboardingData {
     private String subunitCode;
     private String subunitType;
     private String aooParentCode;
+    private String parentDescription;
 
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/MsCoreRestClientTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/MsCoreRestClientTest.java
@@ -190,7 +190,7 @@ class MsCoreRestClientTest extends BaseFeignRestClientTest {
         assertNotNull(response.getInstitutions());
         assertFalse(response.getInstitutions().isEmpty());
         response.getInstitutions().forEach(onboardingData -> {
-            TestUtils.checkNotNullFields(onboardingData, "subunitCode", "subunitType", "aooParentCode");
+            TestUtils.checkNotNullFields(onboardingData, "subunitCode", "subunitType", "aooParentCode", "parentDescription");
             assertNotNull(onboardingData.getAttributes());
             assertFalse(onboardingData.getAttributes().isEmpty());
             onboardingData.getAttributes().forEach(attribute -> {

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/PartyProcessRestClientTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/client/PartyProcessRestClientTest.java
@@ -196,7 +196,7 @@ class PartyProcessRestClientTest extends BaseFeignRestClientTest {
         assertNotNull(response.getInstitutions());
         assertFalse(response.getInstitutions().isEmpty());
         response.getInstitutions().forEach(onboardingData -> {
-            TestUtils.checkNotNullFields(onboardingData, "subunitCode", "subunitType", "aooParentCode");
+            TestUtils.checkNotNullFields(onboardingData, "subunitCode", "subunitType", "aooParentCode", "parentDescription");
             assertNotNull(onboardingData.getAttributes());
             assertFalse(onboardingData.getAttributes().isEmpty());
             onboardingData.getAttributes().forEach(attribute -> {

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
@@ -102,6 +102,10 @@ public class ExchangeTokenService {
         institution.setId(institutionId);
         institution.setName(institutionInfo.getDescription());
         institution.setTaxCode(institutionInfo.getTaxCode());
+        institution.setSubUnitType(institutionInfo.getSubunitType());
+        institution.setSubUnitCode(institutionInfo.getSubunitCode());
+        institution.setAooParent(institutionInfo.getAooParentCode());
+        institution.setParentDescription(institutionInfo.getParentDescription());
         institution.setRoles(productGrantedAuthority.getProductRoles().stream()
                 .map(productRoleCode -> {
                     Role role = new Role();
@@ -189,6 +193,10 @@ public class ExchangeTokenService {
         private List<Role> roles;
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private List<String> groups;
+        private String subUnitCode;
+        private String subUnitType;
+        private String aooParent;
+        private String parentDescription;
     }
 
     @Data

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
@@ -106,6 +106,7 @@ public class ExchangeTokenService {
         institution.setSubUnitCode(institutionInfo.getSubunitCode());
         institution.setAooParent(institutionInfo.getAooParentCode());
         institution.setParentDescription(institutionInfo.getParentDescription());
+        institution.setOriginId(institutionInfo.getOriginId());
         institution.setRoles(productGrantedAuthority.getProductRoles().stream()
                 .map(productRoleCode -> {
                     Role role = new Role();
@@ -197,6 +198,8 @@ public class ExchangeTokenService {
         private String subUnitType;
         private String aooParent;
         private String parentDescription;
+        @JsonProperty("ipaCode")
+        private String originId;
     }
 
     @Data

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -47,6 +47,7 @@ import java.time.Instant;
 import java.util.*;
 
 import static it.pagopa.selfcare.commons.base.security.PartyRole.MANAGER;
+import static it.pagopa.selfcare.commons.utils.TestUtils.checkNotNullFields;
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -465,6 +466,7 @@ class ExchangeTokenServiceTest {
         assertNotNull(institution);
         assertEquals(institutionInfo.getDescription(), institution.getName());
         assertEquals(institutionId, institution.getId());
+        checkNotNullFields(institution);
         assertEquals(1, institution.getRoles().size());
         List<String> groups = institution.getGroups();
         assertEquals(pageable.getPageSize(), groups.size());
@@ -515,6 +517,10 @@ class ExchangeTokenServiceTest {
             institution.setName(o.get("name").toString());
             institution.setTaxCode(o.get("fiscal_code").toString());
             institution.setGroups((List<String>) o.get("groups"));
+            institution.setSubUnitCode(o.get("subUnitCode").toString());
+            institution.setSubUnitType(o.get("subUnitType").toString());
+            institution.setAooParent(o.get("aooParent").toString());
+            institution.setParentDescription(o.get("parentDescription").toString());
             return institution;
         }
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -510,18 +510,18 @@ class ExchangeTokenServiceTest {
         }
 
         public ExchangeTokenService.Institution getInstitution() {
-            LinkedHashMap<String, Object> o = (LinkedHashMap) get(INSTITUTION);
+            LinkedHashMap<String, Object> organizationClaim = (LinkedHashMap) get(INSTITUTION);
             ExchangeTokenService.Institution institution = new ExchangeTokenService.Institution();
-            institution.setId(o.get("id").toString());
-            institution.setRoles((List<ExchangeTokenService.Role>) o.get("roles"));
-            institution.setName(o.get("name").toString());
-            institution.setTaxCode(o.get("fiscal_code").toString());
-            institution.setGroups((List<String>) o.get("groups"));
-            institution.setSubUnitCode(o.get("subUnitCode").toString());
-            institution.setSubUnitType(o.get("subUnitType").toString());
-            institution.setAooParent(o.get("aooParent").toString());
-            institution.setParentDescription(o.get("parentDescription").toString());
-            institution.setOriginId(o.get("ipaCode").toString());
+            institution.setId(organizationClaim.get("id").toString());
+            institution.setRoles((List<ExchangeTokenService.Role>) organizationClaim.get("roles"));
+            institution.setName(organizationClaim.get("name").toString());
+            institution.setTaxCode(organizationClaim.get("fiscal_code").toString());
+            institution.setGroups((List<String>) organizationClaim.get("groups"));
+            institution.setSubUnitCode(organizationClaim.get("subUnitCode").toString());
+            institution.setSubUnitType(organizationClaim.get("subUnitType").toString());
+            institution.setAooParent(organizationClaim.get("aooParent").toString());
+            institution.setParentDescription(organizationClaim.get("parentDescription").toString());
+            institution.setOriginId(organizationClaim.get("ipaCode").toString());
             return institution;
         }
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -521,6 +521,7 @@ class ExchangeTokenServiceTest {
             institution.setSubUnitType(o.get("subUnitType").toString());
             institution.setAooParent(o.get("aooParent").toString());
             institution.setParentDescription(o.get("parentDescription").toString());
+            institution.setOriginId(o.get("ipaCode").toString());
             return institution;
         }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added new claims to the IdentityToken generated by the tokenExchange controller
#### Motivation and Context

Since SC will allow also AOO/UO to onboard products and these products need the additionalFields related to this entities, these has to passed through the organization information claims.
The new fields are subUnitType, subUnitCode, aooParent and parentDescription

#### How Has This Been Tested?

deployed from feature Branch and invoked relative API to assert the presence of the claims in the token

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.