### PR TITLE
Added root parent to token exchange

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
@@ -25,7 +25,6 @@ public class InstitutionInfo {
     private DataProtectionOfficer dataProtectionOfficer;
     private List<GeographicTaxonomy> geographicTaxonomies;
     private SupportContact supportContact;
-
     private String subunitCode;
     private String subunitType;
     private String aooParentCode;

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
@@ -106,6 +106,9 @@ public class ExchangeTokenService {
         institution.setSubUnitCode(institutionInfo.getSubunitCode());
         institution.setAooParent(institutionInfo.getAooParentCode());
         institution.setParentDescription(institutionInfo.getParentDescription());
+        RootParent rootParent = new RootParent();
+        rootParent.setDescription(institutionInfo.getParentDescription());
+        institution.setRootParent(rootParent);
         institution.setOriginId(institutionInfo.getOriginId());
         institution.setRoles(productGrantedAuthority.getProductRoles().stream()
                 .map(productRoleCode -> {
@@ -197,9 +200,17 @@ public class ExchangeTokenService {
         private String subUnitCode;
         private String subUnitType;
         private String aooParent;
+        @Deprecated
         private String parentDescription;
+        private RootParent rootParent;
         @JsonProperty("ipaCode")
         private String originId;
+    }
+
+    @Data
+    static class RootParent implements Serializable {
+        private String id;
+        private String description;
     }
 
     @Data

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -522,6 +522,9 @@ class ExchangeTokenServiceTest {
             institution.setAooParent(organizationClaim.get("aooParent").toString());
             institution.setParentDescription(organizationClaim.get("parentDescription").toString());
             institution.setOriginId(organizationClaim.get("ipaCode").toString());
+            ExchangeTokenService.RootParent rootParent = new ExchangeTokenService.RootParent();
+            rootParent.setDescription(organizationClaim.get("parentDescription").toString());
+            institution.setRootParent(rootParent);
             return institution;
         }
 


### PR DESCRIPTION
#### List of Changes

Added node rootParent to TokenExhange in order to include parent description and parent identifier

#### Motivation and Context

In future, it will be requested to include also parent identifier so all information about root institution has been wrapped into a specific object.