### PR TITLE
Fixed start pagination for brokers

### DIFF
--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PagoPABackOfficeConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PagoPABackOfficeConnectorImpl.java
@@ -23,7 +23,6 @@ public class PagoPABackOfficeConnectorImpl implements PagoPABackOfficeConnector 
     private final MsBackOfficeChannelApiClient backofficeChannelApiClient;
     private final BrokerMapper brokerMapper;
     private static final String DEFAULT_ORDER_DIRECTION = "ASC";
-    private static final String DEFAULT_ORDER_BY = "description";
 
     public PagoPABackOfficeConnectorImpl(MsBackOfficeStationApiClient backofficeStationApiClient,
                                          MsBackOfficeChannelApiClient backofficeChannelApiClient,

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PagoPABackOfficeConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PagoPABackOfficeConnectorImpl.java
@@ -36,7 +36,7 @@ public class PagoPABackOfficeConnectorImpl implements PagoPABackOfficeConnector 
     @Override
     public List<BrokerInfo> getBrokersEC(int page, int limit) {
         log.trace("getBrokersEC start");
-        ResponseEntity<BrokersResource> responseBrokersEC = backofficeStationApiClient._getBrokersECUsingGET(page, limit, null, null, DEFAULT_ORDER_BY, DEFAULT_ORDER_DIRECTION);
+        ResponseEntity<BrokersResource> responseBrokersEC = backofficeStationApiClient._getBrokersECUsingGET(page, limit, null, null, null, DEFAULT_ORDER_DIRECTION);
         log.debug("getBrokersEC result = {}", responseBrokersEC.getBody());
         List<BrokerInfo> brokers = this.parseBrokersEC(responseBrokersEC.getBody());
         log.trace("getBrokersEC end");
@@ -46,7 +46,7 @@ public class PagoPABackOfficeConnectorImpl implements PagoPABackOfficeConnector 
     @Override
     public List<BrokerInfo> getBrokersPSP(int page, int limit) {
         log.trace("getBrokersPSP start");
-        ResponseEntity<BrokersPspResource> responseBrokersPSP = backofficeChannelApiClient._getBrokersPspUsingGET(page, limit, null, null, DEFAULT_ORDER_BY, DEFAULT_ORDER_DIRECTION);
+        ResponseEntity<BrokersPspResource> responseBrokersPSP = backofficeChannelApiClient._getBrokersPspUsingGET(page, limit, null, null, null, DEFAULT_ORDER_DIRECTION);
         log.debug("getBrokersPSP result = {}", responseBrokersPSP.getBody());
         List<BrokerInfo> brokers = this.parseBrokersPSP(responseBrokersPSP.getBody());
         log.trace("getBrokersPSP end");

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImpl.java
@@ -24,7 +24,7 @@ public class BrokerServiceImpl implements BrokerService {
     }
 
     private static final int DEFAULT_LIMIT = 1000;
-    private static final int START_PAGE = 1;
+    private static final int START_PAGE = 0;
 
     @Override
     public List<BrokerInfo> findAllByInstitutionType(String institutionType) {

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImplTest.java
@@ -41,7 +41,7 @@ class BrokerServiceImplTest {
         // then
         Assertions.assertSame(brokersMocked, brokers);
         Mockito.verify(backOfficeConnectorMock, Mockito.times(1))
-                .getBrokersEC(1,1000);
+                .getBrokersEC(0,1000);
         Mockito.verifyNoMoreInteractions(backOfficeConnectorMock);
 
     }
@@ -58,7 +58,7 @@ class BrokerServiceImplTest {
         // then
         Assertions.assertSame(brokersMocked, brokers);
         Mockito.verify(backOfficeConnectorMock, Mockito.times(1))
-                .getBrokersPSP(1,1000);
+                .getBrokersPSP(0,1000);
         Mockito.verifyNoMoreInteractions(backOfficeConnectorMock);
 
     }


### PR DESCRIPTION
#### List of Changes

Changed the default pagination start value from 1 to 0

#### Motivation and Context

This change was due to request of backoffice pagopa team that has exposed api to retrieve brokers considering 0 as default value

#### How Has This Been Tested?

I have run dashboard-backend microservice locally and tested the specific api(/channels/brokers) getting 200 as response
