### PR TITLE
Fix mapper for create delegation

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/MsCoreConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/MsCoreConnector.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.dashboard.connector.model.auth.AuthInfo;
 import it.pagopa.selfcare.dashboard.connector.model.backoffice.BrokerInfo;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.institution.UpdateInstitutionResource;
@@ -32,9 +33,10 @@ public interface MsCoreConnector {
 
     Institution updateInstitutionDescription(String institutionId, UpdateInstitutionResource updatePnPGInstitutionResource);
 
-    DelegationId createDelegation(Delegation delegation);
+    DelegationId createDelegation(DelegationRequest delegation);
 
     List<BrokerInfo> findInstitutionsByProductAndType(String productId, String type);
+
     List<Delegation> getDelegations(String from, String to, String productId);
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationRequest.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationRequest.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.dashboard.connector.model.delegation;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class DelegationRequest {
+    private String id;
+    private String from;
+    private String to;
+    private String productId;
+    private String institutionFromName;
+    private String institutionToName;
+    private DelegationType type;
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImpl.java
@@ -8,6 +8,7 @@ import it.pagopa.selfcare.dashboard.connector.model.auth.AuthInfo;
 import it.pagopa.selfcare.dashboard.connector.model.backoffice.BrokerInfo;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.institution.UpdateInstitutionResource;
@@ -75,6 +76,7 @@ class MsCoreConnectorImpl implements MsCoreConnector {
         log.trace("getOnBoardedInstitutions end");
         return result;
     }
+
     @Override
     public List<InstitutionInfo> getUserProducts(String userId) {
         log.trace("getUserProducts start");
@@ -200,7 +202,7 @@ class MsCoreConnectorImpl implements MsCoreConnector {
     }
 
     @Override
-    public DelegationId createDelegation(Delegation delegation) {
+    public DelegationId createDelegation(DelegationRequest delegation) {
         log.trace("createDelegation start");
         log.debug("createDelegation request = {}", delegation.toString());
         DelegationId result = msCoreRestClient.createDelegation(delegation);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/MsCoreRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/MsCoreRestClient.java
@@ -1,8 +1,8 @@
 package it.pagopa.selfcare.dashboard.connector.rest.client;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.RelationshipState;
 import it.pagopa.selfcare.dashboard.connector.model.institution.UpdateInstitutionResource;
@@ -68,7 +68,7 @@ public interface MsCoreRestClient {
 
     @PostMapping(value = "${rest-client.ms-core.createDelegation.path}")
     @ResponseBody
-    DelegationId createDelegation(@RequestBody Delegation delegation);
+    DelegationId createDelegation(@RequestBody DelegationRequest delegation);
 
 
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImplTest.java
@@ -17,6 +17,7 @@ import it.pagopa.selfcare.dashboard.connector.model.auth.AuthInfo;
 import it.pagopa.selfcare.dashboard.connector.model.backoffice.BrokerInfo;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationType;
 import it.pagopa.selfcare.dashboard.connector.model.institution.*;
 import it.pagopa.selfcare.dashboard.connector.model.product.PartyProduct;
@@ -881,7 +882,7 @@ class MsCoreConnectorImplTest {
     @Test
     void createDelegation() {
         // given
-        Delegation delegation = new Delegation();
+        DelegationRequest delegation = new DelegationRequest();
         delegation.setId("id");
         DelegationId delegationId = new DelegationId();
         delegationId.setId("id");

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationService.java
@@ -2,12 +2,13 @@ package it.pagopa.selfcare.dashboard.core;
 
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 
 import java.util.List;
 
 public interface DelegationService {
 
-    DelegationId createDelegation(Delegation delegation);
+    DelegationId createDelegation(DelegationRequest delegation);
 
     List<Delegation> getDelegations(String from, String to, String productId);
 

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,7 @@ class DelegationServiceImpl implements DelegationService {
     }
 
     @Override
-    public DelegationId createDelegation(Delegation delegation) {
+    public DelegationId createDelegation(DelegationRequest delegation) {
         log.trace("createDelegation start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "createDelegation request = {}", delegation);
         DelegationId result = msCoreConnector.createDelegation(delegation);
@@ -35,7 +36,7 @@ class DelegationServiceImpl implements DelegationService {
     @Override
     public List<Delegation> getDelegations(String from, String to, String productId) {
         log.trace("getDelegations start");
-        log.debug("getDelegations request = {}", from, productId);
+        log.debug("getDelegations from = {}, to = {}, productId = {}", from, to, productId);
         List<Delegation> result = msCoreConnector.getDelegations(from, to, productId);
         log.debug("getDelegations result = {}", result);
         log.trace("getDelegations end");

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.dashboard.core;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,14 +27,14 @@ class DelegationServiceImplTest {
     private DelegationServiceImpl delegationServiceImpl;
 
     /**
-     * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
+     * Method under test: {@link DelegationServiceImpl#createDelegation(DelegationRequest)}
      */
     @Test
     void testCreateDelegation() {
         DelegationId delegationId = new DelegationId();
         delegationId.setId("id");
         when(delegationConnector.createDelegation(any())).thenReturn(delegationId);
-        Delegation delegation = new Delegation();
+        DelegationRequest delegation = new DelegationRequest();
         delegation.setId("id");
         DelegationId response = delegationServiceImpl.createDelegation(delegation);
         verify(delegationConnector).createDelegation(any());

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/DelegationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/DelegationMapper.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.web.model.mapper;
 
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationRequest;
 import it.pagopa.selfcare.dashboard.web.model.delegation.DelegationIdResource;
 import it.pagopa.selfcare.dashboard.web.model.delegation.DelegationRequestDto;
 import it.pagopa.selfcare.dashboard.web.model.delegation.DelegationResource;
@@ -10,7 +11,7 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface DelegationMapper {
 
-    Delegation toDelegation(DelegationRequestDto request);
+    DelegationRequest toDelegation(DelegationRequestDto request);
     DelegationIdResource toIdResource(DelegationId delegationId);
     DelegationResource toDelegationResource(Delegation delegation);
 }


### PR DESCRIPTION
**List of Changes**

- Created new object to send a delegation request to ms-core.
- Added method in DelegationMapper to manage this new entity

**Motivation and Context**

This change was due to a software regression introduced after adding new api to retrieve list of delegations.

**How Has This Been Tested?**

I have run dashboard-backend microservice locally and through Swagger, I have tested the specific api getting 200 as http code response
