### PR TITLE
Added productId as query string in zendesk url

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/support/SupportRequest.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/support/SupportRequest.java
@@ -6,6 +6,7 @@ import lombok.Data;
 public class SupportRequest {
 
     private String email;
+    private String productId;
     private String name;
     private UserField userFields;
 

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.dashboard.connector.model.support.SupportRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -49,7 +50,11 @@ public class SupportServiceImpl implements SupportService {
         String  redirectUrl = "https://" + SUBDOMAIN + ".zendesk.com/access/jwt?jwt=" + jwtString;
         log.debug("sendRequest result = {}", redirectUrl);
         log.trace("sendRequest end");
-        return redirectUrl.concat("&return_to=" + URLEncoder.encode(RETURN_TO, StandardCharsets.UTF_8));
 
+        String returnUrl = StringUtils.hasText(supportRequest.getProductId()) ?
+                URLEncoder.encode(RETURN_TO.concat("?product=" + supportRequest.getProductId()), StandardCharsets.UTF_8) :
+                URLEncoder.encode(RETURN_TO, StandardCharsets.UTF_8);
+
+        return redirectUrl.concat("&return_to=" + returnUrl);
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -29,6 +29,21 @@ class SupportServiceImplTest {
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
     @Test
+    void testSendRequestWithProductId() {
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26");
+        SupportRequest supportRequest = this.dummySupportRequest();
+        supportRequest.setProductId("prodottoDiTest");
+        String url = supportServiceImpl.sendRequest(supportRequest);
+        assertNotNull(url);
+        assertTrue(url.contains("jwt"));
+        assertTrue(url.contains(supportRequest.getProductId()));
+        assertEquals("http", url.substring(0, 4));
+    }
+
+    /**
+     * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
+     */
+    @Test
     void testRequestWithMalformedEmptyKey() {
         SupportServiceImpl supportServiceImpl = new SupportServiceImpl("");
         SupportException exception = assertThrows(SupportException.class, () -> supportServiceImpl.sendRequest(this.dummySupportRequest()));

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/support/SupportRequestDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/support/SupportRequestDto.java
@@ -15,7 +15,7 @@ public class SupportRequestDto {
     @Email @NotBlank
     private String email;
 
-    @ApiModelProperty(value = "${swagger.dashboard.support.model.productId}", required = false)
+    @ApiModelProperty(value = "${swagger.dashboard.support.model.productId}")
     private String productId;
 
 }


### PR DESCRIPTION
#### List of Changes

Added productId as query string in zendesk redirect url

#### Motivation and Context

This change was necessary to allow assistance layer to manage productId into zendesk form

#### How Has This Been Tested?

I have run dashboard backend application locally and tested the specific api **/support**
