### PR TITLE
fix: remove non-matching products from user's products

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImpl.java
@@ -256,7 +256,8 @@ class InstitutionServiceImpl implements InstitutionService {
                         .anyMatch(key::equals)) {
                     productsIterator.remove();
                 } else {
-                    throw new IllegalArgumentException(String.format("No matching product found with id %s", key));
+                    productsIterator.remove();
+                    log.warn("No matching product found with id {}", key);
                 }
             }
         });

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/InstitutionServiceImplTest.java
@@ -220,7 +220,7 @@ class InstitutionServiceImplTest {
         List<ProductTree> products = institutionService.getProductsTree();
         //then
         Assertions.assertNotNull(products);
-        Assertions.assertTrue(products.size() == 1);
+        assertEquals(1, products.size());
         verify(productsConnectorMock, times(1)).getProductsTree();
         verifyNoMoreInteractions(productsConnectorMock);
         verifyNoInteractions(partyConnectorMock);
@@ -851,30 +851,49 @@ class InstitutionServiceImplTest {
         userInfoFilter.setUserId(userId);
         UserInfo userInfoMock = mockInstance(new UserInfo(), "setProducts");
         final ProductInfo productInfoMock = mockInstance(new ProductInfo(), 1, "setRoleInfos");
-        userInfoMock.setProducts(Map.of(productInfoMock.getId(), productInfoMock));
+        Map<String, ProductInfo> map = new HashMap<>();
+        map.put(productInfoMock.getId(), productInfoMock);
+        userInfoMock.setProducts(map);
         when(partyConnectorMock.getUsers(any(), any()))
                 .thenReturn(List.of(userInfoMock));
         final ProductTree productTree = mockInstance(new ProductTree(), 2, "setChildren");
         productTree.setChildren(Collections.emptyList());
         when(productsConnectorMock.getProductsTree())
                 .thenReturn(List.of(productTree));
+        User user = new User();
+        user.setId("id");
+        CertifiedField<String> nameCert = new CertifiedField<>();
+        nameCert.setValue("name");
+        user.setName(nameCert);
+        CertifiedField<String> surnameCert = new CertifiedField<>();
+        surnameCert.setValue("surname");
+        user.setFamilyName(surnameCert);
+        user.setFiscalCode("fiscalCode");
+        CertifiedField<String> mailCert = new CertifiedField<>();
+        mailCert.setValue("surname");
+        user.setEmail(mailCert);
+        user.setWorkContacts(new HashMap<>());
+        when(userRegistryConnector.getUserByInternalId(any(), any())).thenReturn(user);
         // when
-        Executable executable = () -> institutionService.getInstitutionUser(institutionId, userId.get());
-        // then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        Assertions.assertEquals("No matching product found with id " + productInfoMock.getId(), e.getMessage());
-        ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
+        UserInfo userInfo = institutionService.getInstitutionUser(institutionId, userId.get());
+
+        Assertions.assertNotNull(userInfo.getProducts());
+        Assertions.assertEquals(0, userInfo.getProducts().size());
+        TestUtils.checkNotNullFields(userInfo);
+        TestUtils.checkNotNullFields(userInfo.getUser());
         verify(partyConnectorMock, times(1))
-                .getUsers(Mockito.eq(institutionId), filterCaptor.capture());
-        UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
-        assertEquals(Optional.empty(), capturedFilter.getRole());
-        assertEquals(Optional.empty(), capturedFilter.getProductId());
-        assertEquals(Optional.empty(), capturedFilter.getProductRoles());
-        assertEquals(userId, capturedFilter.getUserId());
-        assertEquals(Optional.of(EnumSet.of(ACTIVE, SUSPENDED)), capturedFilter.getAllowedStates());
+                .getUsers(Mockito.eq(institutionId), any(UserInfo.UserInfoFilter.class));
         verify(productsConnectorMock, times(1))
                 .getProductsTree();
-        verifyNoMoreInteractions(partyConnectorMock, productsConnectorMock, userRegistryConnector);
+        ArgumentCaptor<EnumSet<Fields>> fieldsCaptor = ArgumentCaptor.forClass(EnumSet.class);
+        verify(userRegistryConnector, times(1))
+                .getUserByInternalId(any(), fieldsCaptor.capture());
+        EnumSet<Fields> capturedFields = fieldsCaptor.getValue();
+        assertTrue(capturedFields.contains(name));
+        assertTrue(capturedFields.contains(familyName));
+        assertTrue(capturedFields.contains(workContacts));
+        assertTrue(capturedFields.contains(fiscalCode));
+        verifyNoMoreInteractions(partyConnectorMock, productsConnectorMock);
     }
 
 


### PR DESCRIPTION
#### List of Changes

remove non-matching products from user instead of throw exception

#### Motivation and Context

Api throws an exception even if only one user's product non-match with productList

#### How Has This Been Tested?
 call this api with user that have active onboarding for deleted product.
