### PR TITLE
[Bugfix/selc 3250] - feat: overwrite user personal email in exchange token

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
-* @pagopa/selfcare-contributors @KevinSi96 @SalvatorManna @manuraf 
+* @pagopa/selfcare-contributors

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <description>Self Care Dashboard Backend</description>
 
     <properties>
-        <selc-commons.version>2.4.7</selc-commons.version>
+        <selc-commons.version>2.4.9</selc-commons.version>
     </properties>
 
     <dependencyManagement>

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/handler/DashboardExceptionsHandler.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/handler/DashboardExceptionsHandler.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.dashboard.core.exception.InvalidProductRoleException;
 import it.pagopa.selfcare.dashboard.core.exception.InvalidUserGroupException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -66,6 +67,12 @@ public class DashboardExceptionsHandler {
     ResponseEntity<Problem> handleRuntimeException(RuntimeException e) {
         log.error(e.toString());
         return ProblemMapper.toResponseEntity(new Problem(INTERNAL_SERVER_ERROR, e.getMessage()));
+    }
+
+    @ExceptionHandler({AccessDeniedException.class})
+    ResponseEntity<Problem> handleAccessDeniedException(AccessDeniedException e) {
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(FORBIDDEN, e.getMessage()));
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenService.java
@@ -14,8 +14,10 @@ import it.pagopa.selfcare.dashboard.connector.api.ProductsConnector;
 import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupInfo;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.product.Product;
+import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.core.InstitutionService;
 import it.pagopa.selfcare.dashboard.core.UserGroupService;
+import it.pagopa.selfcare.dashboard.core.UserService;
 import it.pagopa.selfcare.dashboard.web.config.ExchangeTokenProperties;
 import it.pagopa.selfcare.dashboard.web.model.ExchangedToken;
 import lombok.Data;
@@ -54,6 +56,7 @@ public class ExchangeTokenService {
     private final String kid;
     private final InstitutionService institutionService;
     private final UserGroupService groupService;
+    public final UserService userService;
     private final ProductsConnector productsConnector;
     private final String issuer;
 
@@ -61,7 +64,7 @@ public class ExchangeTokenService {
                                 InstitutionService institutionService,
                                 UserGroupService groupService,
                                 ProductsConnector productConnector,
-                                ExchangeTokenProperties properties) throws InvalidKeySpecException, NoSuchAlgorithmException {
+                                ExchangeTokenProperties properties, UserService userService) throws InvalidKeySpecException, NoSuchAlgorithmException {
         this.jwtService = jwtService;
         this.productsConnector = productConnector;
         this.institutionService = institutionService;
@@ -70,6 +73,7 @@ public class ExchangeTokenService {
         this.issuer = properties.getIssuer();
         this.duration = Duration.parse(properties.getDuration());
         this.kid = properties.getKid();
+        this.userService = userService;
     }
 
 
@@ -98,6 +102,9 @@ public class ExchangeTokenService {
         TokenExchangeClaims claims = new TokenExchangeClaims(selcClaims);
         claims.setId(UUID.randomUUID().toString());
         claims.setIssuer(issuer);
+        User user = userService.getUserByInternalId(UUID.fromString(principal.getId()));
+        String email = user.getWorkContact(institutionId).getEmail().getValue();
+        claims.setEmail(email);
         Institution institution = new Institution();
         institution.setId(institutionId);
         institution.setName(institutionInfo.getDescription());
@@ -225,6 +232,7 @@ public class ExchangeTokenService {
     static class TokenExchangeClaims extends DefaultClaims {
         public static final String DESIRED_EXPIRATION = "desired_exp";
         public static final String INSTITUTION = "organization";
+        public static final String EMAIL = "email";
 
         public TokenExchangeClaims(Map<String, Object> map) {
             super(map);
@@ -239,6 +247,11 @@ public class ExchangeTokenService {
             setValue(INSTITUTION, institution);
             return this;
         }
+
+        public Claims setEmail(String email){
+            setValue(EMAIL, email);
+            return this;
+        };
 
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/handler/DashboardExceptionsHandlerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/handler/DashboardExceptionsHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 
 import javax.validation.ValidationException;
 
@@ -107,6 +108,25 @@ class DashboardExceptionsHandlerTest {
         assertNotNull(responseEntity.getBody());
         assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
         assertEquals(INTERNAL_SERVER_ERROR.value(), responseEntity.getBody().getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            AccessDeniedException.class
+    })
+    void handleAccessDeniedException(Class<?> clazz) {
+        // given
+        AccessDeniedException exceptionMock = (AccessDeniedException) Mockito.mock(clazz);
+        Mockito.when(exceptionMock.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        // when
+        ResponseEntity<Problem> responseEntity = handler.handleAccessDeniedException(exceptionMock);
+        // then
+        assertNotNull(responseEntity);
+        assertEquals(FORBIDDEN, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(FORBIDDEN.value(), responseEntity.getBody().getStatus());
     }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -75,7 +75,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         // when
-        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties);
+        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties, null);
         // then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
         assertTrue(e.getMessage().startsWith("Illegal base64"));
@@ -91,7 +91,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         // when
-        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties);
+        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties, null);
         // then
         assertThrows(InvalidKeySpecException.class, executable);
     }
@@ -106,7 +106,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         // when
-        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties);
+        Executable executable = () -> new ExchangeTokenService(null, null, null, null, properties, null);
         // then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
         assertTrue(e.getMessage().startsWith("failed to construct sequence from byte[]"));
@@ -122,7 +122,7 @@ class ExchangeTokenServiceTest {
         properties.setSigningKey(jwtSigningKey);
         properties.setDuration("PT5S");
         JwtService jwtServiceMock = mock(JwtService.class);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties, null);
         // when
         Executable executable = () -> exchangeTokenService.exchange(null, null, null);
         // then
@@ -143,7 +143,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         properties.setDuration("PT5S");
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties, null);
         TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password");
         TestSecurityContextHolder.setAuthentication(authentication);
         // when
@@ -166,7 +166,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         properties.setDuration("PT5S");
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties, null);
         List<ProductGrantedAuthority> roleOnProducts = List.of(new ProductGrantedAuthority(MANAGER, "productRole", productId));
         List<GrantedAuthority> authorities = List.of(new SelfCareGrantedAuthority("differentInstitutionId", roleOnProducts));
         TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", authorities);
@@ -191,7 +191,7 @@ class ExchangeTokenServiceTest {
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
         properties.setSigningKey(jwtSigningKey);
         properties.setDuration("PT5S");
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties, null);
         List<ProductGrantedAuthority> roleOnProducts = List.of(new ProductGrantedAuthority(MANAGER, "productRole", "differentProductId"));
         List<GrantedAuthority> authorities = List.of(new SelfCareGrantedAuthority(institutionId, roleOnProducts));
         TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", authorities);
@@ -218,7 +218,7 @@ class ExchangeTokenServiceTest {
         JwtService jwtServiceMock = mock(JwtService.class);
         when(jwtServiceMock.getClaims(any()))
                 .thenReturn(null);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, null, null, null, properties, null);
         List<ProductGrantedAuthority> roleOnProducts = List.of(new ProductGrantedAuthority(MANAGER, "productRole", productId));
         List<GrantedAuthority> authorities = List.of(new SelfCareGrantedAuthority(institutionId, roleOnProducts));
         TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", authorities);
@@ -258,7 +258,7 @@ class ExchangeTokenServiceTest {
         InstitutionService institutionServiceMock = mock(InstitutionService.class);
         ProductsConnector productsConnectorMock = mock(ProductsConnector.class);
         UserGroupService groupServiceMock = mock(UserGroupService.class);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, null);
         List<ProductGrantedAuthority> roleOnProducts = List.of(new ProductGrantedAuthority(MANAGER, "productRole", productId));
         List<GrantedAuthority> authorities = List.of(new SelfCareGrantedAuthority(institutionId, roleOnProducts));
         TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", authorities);
@@ -331,7 +331,7 @@ class ExchangeTokenServiceTest {
         environmentVariables.set("JWT_TOKEN_EXCHANGE_ISSUER", "https://dev.selfcare.pagopa.it");
         String issuer = "https://dev.selfcare.pagopa.it";
         properties.setIssuer(issuer);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, null);
         // when
         final ExchangedToken exchangedToken = exchangeTokenService.exchange(institutionId, productId, Optional.empty());
         // then
@@ -437,7 +437,7 @@ class ExchangeTokenServiceTest {
         properties.setKid(kid);
         properties.setDuration("PT5S");
         properties.setIssuer(issuer);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, null);
         // when
         final ExchangedToken exchangedToken = exchangeTokenService.exchange(institutionId, productId, Optional.empty());
         // then

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceTest.java
@@ -13,9 +13,13 @@ import it.pagopa.selfcare.dashboard.connector.model.groups.UserGroupInfo;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.product.Product;
 import it.pagopa.selfcare.dashboard.connector.model.product.ProductRoleInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.CertifiedField;
+import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.WorkContact;
 import it.pagopa.selfcare.dashboard.core.InstitutionService;
 import it.pagopa.selfcare.dashboard.core.UserGroupService;
+import it.pagopa.selfcare.dashboard.core.UserService;
 import it.pagopa.selfcare.dashboard.web.config.ExchangeTokenProperties;
 import it.pagopa.selfcare.dashboard.web.model.ExchangedToken;
 import lombok.Getter;
@@ -331,7 +335,18 @@ class ExchangeTokenServiceTest {
         environmentVariables.set("JWT_TOKEN_EXCHANGE_ISSUER", "https://dev.selfcare.pagopa.it");
         String issuer = "https://dev.selfcare.pagopa.it";
         properties.setIssuer(issuer);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, null);
+        UserService userService = mock(UserService.class);
+        User user = new User();
+        user.setId(UUID.randomUUID().toString());
+        Map<String, WorkContact> workContactMap = new HashMap<>();
+        WorkContact contact = new WorkContact();
+        CertifiedField<String> email =  new CertifiedField<>();
+        email.setValue("email");
+        contact.setEmail(email);
+        workContactMap.put(institutionId, contact);
+        user.setWorkContacts(workContactMap);
+        when(userService.getUserByInternalId(any())).thenReturn(user);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, userService);
         // when
         final ExchangedToken exchangedToken = exchangeTokenService.exchange(institutionId, productId, Optional.empty());
         // then
@@ -401,6 +416,7 @@ class ExchangeTokenServiceTest {
                         .setIssuedAt(iat)
                         .setExpiration(exp));
         InstitutionService institutionServiceMock = mock(InstitutionService.class);
+        UserService userService = mock(UserService.class);
         InstitutionInfo institutionInfo = mockInstance(new InstitutionInfo());
         when(institutionServiceMock.getInstitution(any()))
                 .thenReturn(institutionInfo);
@@ -437,7 +453,17 @@ class ExchangeTokenServiceTest {
         properties.setKid(kid);
         properties.setDuration("PT5S");
         properties.setIssuer(issuer);
-        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, null);
+        User pdvUser = new User();
+        pdvUser.setId(UUID.randomUUID().toString());
+        Map<String, WorkContact> workContactMap = new HashMap<>();
+        WorkContact contact = new WorkContact();
+        CertifiedField<String> email =  new CertifiedField<>();
+        email.setValue("email");
+        contact.setEmail(email);
+        workContactMap.put(institutionId, contact);
+        pdvUser.setWorkContacts(workContactMap);
+        when(userService.getUserByInternalId(any())).thenReturn(pdvUser);
+        ExchangeTokenService exchangeTokenService = new ExchangeTokenService(jwtServiceMock, institutionServiceMock, groupServiceMock, productsConnectorMock, properties, userService);
         // when
         final ExchangedToken exchangedToken = exchangeTokenService.exchange(institutionId, productId, Optional.empty());
         // then


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
In the exchange token service the email claim gets overwritten with the mail associated to the institution the user has been onboarded for
#### Motivation and Context

Currently the email claim present in the exchange token is the personal email the user used to register on the spid service, the vertical's doesn't need to know this email, they need the email the user used to onbaord an institution

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.