### PR TITLE
[SELC-3460] feat: added tag external-v2 for automatic generation of open-api

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.web.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.dashboard.connector.model.support.SupportResponse;
@@ -31,6 +32,7 @@ public class SupportController {
         this.supportMapper = supportMapper;
     }
 
+    @Tag(name = "external-v2")
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.dashboard.support.api.sendRequest}")


### PR DESCRIPTION
#### List of Changes

Added new tag external-v2 for operation that will be include into open-api for APIM

#### Motivation and Context

In order to avoid manual construction of open-api for APIM, all operations that will be included into this document are tagged with external-v2 or support. In this way, a step of github action will scan them and automatically include into open-api.