### PR TITLE
[SELC-3964] - Mapped fields of institution from token's Institution data

### DIFF
--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
@@ -14,10 +14,7 @@ import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
 import it.pagopa.selfcare.dashboard.connector.onboarding.OnboardingRequestInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.client.PartyManagementRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.PartyProcessRestClient;
-import it.pagopa.selfcare.dashboard.connector.rest.model.InstitutionPut;
-import it.pagopa.selfcare.dashboard.connector.rest.model.ProductState;
-import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipInfo;
-import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipsResponse;
+import it.pagopa.selfcare.dashboard.connector.rest.model.*;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnBoardingInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnboardingUsersRequest;
@@ -36,6 +33,7 @@ import org.springframework.util.Assert;
 
 import javax.validation.ValidationException;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -82,18 +80,18 @@ class PartyConnectorImpl implements PartyConnector {
         return institutionInfo;
     };
 
-    protected static final Function<Institution, InstitutionInfo> INSTITUTION_TO_INSTITUTION_INFO_FUNCTION = institution -> {
+    protected static final BiFunction<Institution, InstitutionUpdate, InstitutionInfo> INSTITUTION_TO_INSTITUTION_INFO_FUNCTION = (institution, institutionUpdate) -> {
         InstitutionInfo institutionInfo = new InstitutionInfo();
         institutionInfo.setId(institution.getId());
         institutionInfo.setInstitutionType(institution.getInstitutionType());
-        institutionInfo.setDescription(institution.getDescription());
-        institutionInfo.setTaxCode(institution.getTaxCode());
-        institutionInfo.setDigitalAddress(institution.getDigitalAddress());
-        institutionInfo.setAddress(institution.getAddress());
+        institutionInfo.setDescription(institutionUpdate.getDescription());
+        institutionInfo.setTaxCode(institutionUpdate.getTaxCode());
+        institutionInfo.setDigitalAddress(institutionUpdate.getDigitalAddress());
+        institutionInfo.setAddress(institutionUpdate.getAddress());
         institutionInfo.setCity(institution.getCity());
         institutionInfo.setCountry(institution.getCountry());
         institutionInfo.setCounty(institution.getCounty());
-        institutionInfo.setZipCode(institution.getZipCode());
+        institutionInfo.setZipCode(institutionUpdate.getZipCode());
         institutionInfo.setPaymentServiceProvider(institution.getPaymentServiceProvider());
         institutionInfo.setDataProtectionOfficer(institution.getDataProtectionOfficer());
         institutionInfo.setBilling(institution.getBilling());
@@ -487,7 +485,7 @@ class PartyConnectorImpl implements PartyConnector {
             }
         });
         Institution institution = partyProcessRestClient.getInstitution(tokenInfo.getInstitutionId());
-        InstitutionInfo institutionInfo = INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institution);
+        InstitutionInfo institutionInfo = INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institution, tokenInfo.getInstitutionUpdate());
         institutionInfo.setStatus(tokenInfo.getStatus());
         OnboardedProduct onboardedProduct = institution.getOnboarding().stream()
                 .filter(onboarding -> onboarding.getProductId().equals(tokenInfo.getProductId()))

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImpl.java
@@ -370,7 +370,7 @@ class PartyConnectorImpl implements PartyConnector {
         RelationshipsResponse institutionRelationships = partyProcessRestClient.getUserInstitutionRelationships(institutionId, EnumSet.allOf(PartyRole.class), userInfoFilter.getAllowedStates().orElse(null), userInfoFilter.getProductId().map(Set::of).orElse(null), userInfoFilter.getProductRoles().orElse(null), userInfoFilter.getUserId().orElse(null));
         if (!institutionRelationships.isEmpty()) {
             Set<PartyRole> roles = partyRoleToUsersMap.keySet();
-            List<PartyRole> partyRoles = institutionRelationships.stream().map(RelationshipInfo::getRole).collect(Collectors.toList());
+            List<PartyRole> partyRoles = institutionRelationships.stream().map(RelationshipInfo::getRole).toList();
 
             if(checkUserRole(userDto, institutionRelationships)){
                 throw new ValidationException("User role conflict");

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/token/TokenInfo.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/token/TokenInfo.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.dashboard.connector.rest.model.token;
 
 import it.pagopa.selfcare.dashboard.connector.model.institution.RelationshipState;
+import it.pagopa.selfcare.dashboard.connector.rest.model.InstitutionUpdate;
 import it.pagopa.selfcare.dashboard.connector.rest.model.relationship.RelationshipBinding;
 import lombok.Data;
 
@@ -16,5 +17,6 @@ public class TokenInfo {
     private RelationshipState status;
     private String institutionId;
     private String productId;
+    private InstitutionUpdate institutionUpdate;
 
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/MsCoreConnectorImplTest.java
@@ -27,6 +27,7 @@ import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.client.MsCoreDelegationApiRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.MsCoreRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.MsCoreUserApiRestClient;
+import it.pagopa.selfcare.dashboard.connector.rest.model.InstitutionUpdate;
 import it.pagopa.selfcare.dashboard.connector.rest.model.ProductState;
 import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipsResponse;
@@ -820,8 +821,9 @@ class MsCoreConnectorImplTest {
     void institutionToInstitutionInfoFunction() {
         // given
         Institution institutionMock = mockInstance(new Institution());
+        InstitutionUpdate institutionUpdateMock = mockInstance(new InstitutionUpdate());
         // when
-        final InstitutionInfo result = PartyConnectorImpl.INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institutionMock);
+        final InstitutionInfo result = PartyConnectorImpl.INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institutionMock, institutionUpdateMock);
         // then
         assertEquals(institutionMock.getInstitutionType(), result.getInstitutionType());
         assertEquals(institutionMock.getDescription(), result.getDescription());

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/PartyConnectorImplTest.java
@@ -20,10 +20,7 @@ import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
 import it.pagopa.selfcare.dashboard.connector.onboarding.OnboardingRequestInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.client.PartyManagementRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.PartyProcessRestClient;
-import it.pagopa.selfcare.dashboard.connector.rest.model.InstitutionPut;
-import it.pagopa.selfcare.dashboard.connector.rest.model.ProductState;
-import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipInfo;
-import it.pagopa.selfcare.dashboard.connector.rest.model.RelationshipsResponse;
+import it.pagopa.selfcare.dashboard.connector.rest.model.*;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnBoardingInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.dashboard.connector.rest.model.onboarding.OnboardingUsersRequest;
@@ -1448,8 +1445,9 @@ class PartyConnectorImplTest {
     void institutionToInstitutionInfoFunction() {
         // given
         Institution institutionMock = mockInstance(new Institution());
+        InstitutionUpdate institutionUpdateMock = mockInstance(new InstitutionUpdate());
         // when
-        final InstitutionInfo result = PartyConnectorImpl.INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institutionMock);
+        final InstitutionInfo result = PartyConnectorImpl.INSTITUTION_TO_INSTITUTION_INFO_FUNCTION.apply(institutionMock, institutionUpdateMock);
         // then
         assertEquals(institutionMock.getInstitutionType(), result.getInstitutionType());
         assertEquals(institutionMock.getDescription(), result.getDescription());


### PR DESCRIPTION
#### List of Changes

Obtained InstitutionUpdate object from Token entity, and used some of its data to map the institution to return

#### Motivation and Context

The api that allows you to show a pending onboarding data, used to get the institution data from the Institution collection. Instead now some of the institution data is obtained from the Token collection.


#### How Has This Been Tested?

Local env