### PR TITLE
[SELC - 4017] feat: changed process to redirect to Zendesk Page when user is logged in

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2104,9 +2104,9 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "application/json" : {
+              "text/html" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SupportResponse"
+                  "type" : "string"
                 }
               }
             }
@@ -4649,15 +4649,6 @@
           "productId" : {
             "type" : "string",
             "description" : "Product's identifier"
-          }
-        }
-      },
-      "SupportResponse" : {
-        "title" : "SupportResponse",
-        "type" : "object",
-        "properties" : {
-          "redirectUrl" : {
-            "type" : "string"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/exception/SupportException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/exception/SupportException.java
@@ -4,4 +4,7 @@ public class SupportException extends RuntimeException {
     public SupportException(String message) {
         super(message);
     }
+    public SupportException(String message, Throwable t) {
+        super(message, t);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -23,17 +23,19 @@ public class SupportServiceImpl implements SupportService {
     private final String supportApiKey;
     private final String zendeskOrganization;
     private final String returnTo;
-    private static final String redirectUrl  = "https://pagopa.zendesk.com/access/jwt";
+    private final String redirectUrl;
     @Qualifier("zendeskFreeMarker")
     private final FreeMarkerConfigurer freeMarkerConfigurer;
 
     public SupportServiceImpl(@Value("${support.api.key}") String supportApiKey,
                               @Value("${support.api.zendesk.redirectUri}") String returnTo,
                               @Value("${support.api.zendesk.organization}") String zendeskOrganization,
+                              @Value("${support.api.zendesk.actionUri}") String redirectUrl,
                               FreeMarkerConfigurer freeMarkerConfigurer) {
         this.supportApiKey = supportApiKey;
         this.returnTo = returnTo;
         this.zendeskOrganization = zendeskOrganization;
+        this.redirectUrl = redirectUrl;
         this.freeMarkerConfigurer = freeMarkerConfigurer;
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -12,10 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+
+import java.util.*;
+
 
 @Slf4j
 @Service
@@ -59,9 +58,12 @@ public class SupportServiceImpl implements SupportService {
             throw new SupportException(e.getMessage());
         }
 
+        String redirectToProduct = Objects.nonNull(supportRequest.getProductId()) ?
+                returnTo.concat("?product=" + supportRequest.getProductId()) : returnTo;
+
         Map<String, String> map = new HashMap<>();
         map.put("jwt", jwtString);
-        map.put("returnTo", returnTo);
+        map.put("returnTo", redirectToProduct);
         map.put("action", redirectUrl);
 
         String html;

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -1,17 +1,20 @@
 package it.pagopa.selfcare.dashboard.core;
 
+import freemarker.template.Template;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import it.pagopa.selfcare.dashboard.connector.exception.SupportException;
 import it.pagopa.selfcare.dashboard.connector.model.support.SupportRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -21,14 +24,18 @@ public class SupportServiceImpl implements SupportService {
     private final String supportApiKey;
     private final String zendeskOrganization;
     private final String returnTo;
-    private static final String SUBDOMAIN  = "pagopa";
+    private static final String redirectUrl  = "https://pagopa.zendesk.com/access/jwt";
+    @Qualifier("zendeskFreeMarker")
+    private final FreeMarkerConfigurer freeMarkerConfigurer;
 
     public SupportServiceImpl(@Value("${support.api.key}") String supportApiKey,
                               @Value("${support.api.zendesk.redirectUri}") String returnTo,
-                              @Value("${support.api.zendesk.organization}") String zendeskOrganization) {
+                              @Value("${support.api.zendesk.organization}") String zendeskOrganization,
+                              FreeMarkerConfigurer freeMarkerConfigurer) {
         this.supportApiKey = supportApiKey;
         this.returnTo = returnTo;
         this.zendeskOrganization = zendeskOrganization;
+        this.freeMarkerConfigurer = freeMarkerConfigurer;
     }
 
     @Override
@@ -45,20 +52,31 @@ public class SupportServiceImpl implements SupportService {
                     .claim("email", supportRequest.getEmail())
                     .claim("organization", zendeskOrganization)
                     .claim("user_fields", supportRequest.getUserFields())
-                    .signWith(SignatureAlgorithm.HS256,supportApiKey.getBytes())
+                    .signWith(SignatureAlgorithm.HS256, supportApiKey.getBytes())
                     .compact();
         } catch(Exception e) {
             log.error("Impossible to sign zendesk jwt. Error: {}", e.getMessage(), e);
             throw new SupportException(e.getMessage());
         }
-        String  redirectUrl = "https://" + SUBDOMAIN + ".zendesk.com/access/jwt?jwt=" + jwtString;
-        log.debug("sendRequest result = {}", redirectUrl);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("jwt", jwtString);
+        map.put("returnTo", returnTo);
+        map.put("action", redirectUrl);
+
+        String html;
+
+        try {
+            Template freemarkerTemplate = freeMarkerConfigurer.getConfiguration()
+                    .getTemplate("/template-zendesk-form.ftl");
+            html = FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, map);
+        } catch (Exception e){
+            String errorMessage = "Impossible to retrieve zendesk form template";
+            log.error(errorMessage);
+            throw new SupportException(errorMessage, e);
+        }
+
         log.trace("sendRequest end");
-
-        String returnUrl = StringUtils.hasText(supportRequest.getProductId()) ?
-                URLEncoder.encode(returnTo.concat("?product=" + supportRequest.getProductId()), StandardCharsets.UTF_8) :
-                URLEncoder.encode(returnTo, StandardCharsets.UTF_8);
-
-        return redirectUrl.concat("&return_to=" + returnUrl);
+        return html;
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/config/CoreConfig.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/config/CoreConfig.java
@@ -1,10 +1,13 @@
 package it.pagopa.selfcare.dashboard.core.config;
 
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.TemplateLoader;
 import freemarker.template.TemplateException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration;
@@ -16,6 +19,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 import java.net.URL;
 import java.util.Properties;
@@ -46,6 +50,16 @@ class CoreConfig implements AsyncConfigurer {
         configuration.setTemplateLoader(new CloudTemplateLoader(rootTemplateUrl));
         configuration.setSettings(settings);
         return configuration;
+    }
+
+    @Bean("zendeskFreeMarker")
+    public FreeMarkerConfigurer freemarkerClassLoaderConfig() {
+        freemarker.template.Configuration configuration = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_27);
+        TemplateLoader templateLoader = new ClassTemplateLoader(this.getClass(), "/template-zendesk");
+        configuration.setTemplateLoader(templateLoader);
+        FreeMarkerConfigurer freeMarkerConfigurer = new FreeMarkerConfigurer();
+        freeMarkerConfigurer.setConfiguration(configuration);
+        return freeMarkerConfigurer;
     }
 
 

--- a/core/src/main/resources/template-zendesk/template-zendesk-form.ftl
+++ b/core/src/main/resources/template-zendesk/template-zendesk-form.ftl
@@ -1,0 +1,10 @@
+<html>
+   <head></head>
+   <body>
+<form id="jwtForm" method="POST" action="${action}">
+         <input id="jwtString" type="hidden" name="jwt" value="${jwt}"/>
+         <input id="returnTo" type="hidden" name="return_to" value="${returnTo}"/>
+         </form>
+         <script>window.onload = () => { document.forms["jwtForm"].submit(); };</script>
+    </body>
+</html>

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -1,45 +1,60 @@
 package it.pagopa.selfcare.dashboard.core;
 
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.TemplateLoader;
 import it.pagopa.selfcare.dashboard.connector.exception.SupportException;
 import it.pagopa.selfcare.dashboard.connector.model.support.SupportRequest;
 import it.pagopa.selfcare.dashboard.connector.model.support.UserField;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith({MockitoExtension.class})
 class SupportServiceImplTest {
 
-
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
-    /*@Test
-    void testSendRequest() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", null);
+    @Test
+    void testSendRequest(){
+        FreeMarkerConfigurer freeMarkerConfigurer = freemarkerClassLoaderConfig();
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", freeMarkerConfigurer);
         String url = supportServiceImpl.sendRequest(this.dummySupportRequest());
         assertNotNull(url);
         assertTrue(url.contains("jwt"));
-        assertEquals("http", url.substring(0, 4));
-    }*/
+        assertEquals("<html>", url.substring(0, 6));
+    }
 
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
-    /*@Test
+    @Test
+    void testSendRequestThrowException() {
+        FreeMarkerConfigurer freeMarkerConfigurer = Mockito.mock(FreeMarkerConfigurer.class);
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", freeMarkerConfigurer);
+        Exception exception = assertThrows(Exception.class, () -> supportServiceImpl.sendRequest(this.dummySupportRequest()));
+        assertEquals("Impossible to retrieve zendesk form template", exception.getMessage());
+    }
+
+    /**
+     * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
+     */
+    @Test
     void testSendRequestWithProductId() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", null);
+        FreeMarkerConfigurer freeMarkerConfigurer = freemarkerClassLoaderConfig();
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", freeMarkerConfigurer);
         SupportRequest supportRequest = this.dummySupportRequest();
         supportRequest.setProductId("prodottoDiTest");
         String url = supportServiceImpl.sendRequest(supportRequest);
         assertNotNull(url);
         assertTrue(url.contains("jwt"));
         assertTrue(url.contains(supportRequest.getProductId()));
-        assertEquals("http", url.substring(0, 4));
-    }*/
-
+        assertEquals("<html>", url.substring(0, 6));
+    }
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
@@ -58,5 +73,13 @@ class SupportServiceImplTest {
         userField.setAux_data("PPL89M");
         supportRequest.setUserFields(userField);
         return supportRequest;
+    }
+    private FreeMarkerConfigurer freemarkerClassLoaderConfig() {
+        freemarker.template.Configuration configuration = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_27);
+        TemplateLoader templateLoader = new ClassTemplateLoader(this.getClass(), "/template-zendesk");
+        configuration.setTemplateLoader(templateLoader);
+        FreeMarkerConfigurer freeMarkerConfigurer = new FreeMarkerConfigurer();
+        freeMarkerConfigurer.setConfiguration(configuration);
+        return freeMarkerConfigurer;
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -16,19 +16,19 @@ class SupportServiceImplTest {
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
-    @Test
+    /*@Test
     void testSendRequest() {
         SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", null);
         String url = supportServiceImpl.sendRequest(this.dummySupportRequest());
         assertNotNull(url);
         assertTrue(url.contains("jwt"));
         assertEquals("http", url.substring(0, 4));
-    }
+    }*/
 
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}
      */
-    @Test
+    /*@Test
     void testSendRequestWithProductId() {
         SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", null);
         SupportRequest supportRequest = this.dummySupportRequest();
@@ -38,7 +38,7 @@ class SupportServiceImplTest {
         assertTrue(url.contains("jwt"));
         assertTrue(url.contains(supportRequest.getProductId()));
         assertEquals("http", url.substring(0, 4));
-    }
+    }*/
 
     /**
      * Method under test: {@link SupportServiceImpl#sendRequest(SupportRequest)}

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -18,7 +18,7 @@ class SupportServiceImplTest {
      */
     @Test
     void testSendRequest() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization");
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", null);
         String url = supportServiceImpl.sendRequest(this.dummySupportRequest());
         assertNotNull(url);
         assertTrue(url.contains("jwt"));
@@ -30,7 +30,7 @@ class SupportServiceImplTest {
      */
     @Test
     void testSendRequestWithProductId() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "");
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", null);
         SupportRequest supportRequest = this.dummySupportRequest();
         supportRequest.setProductId("prodottoDiTest");
         String url = supportServiceImpl.sendRequest(supportRequest);
@@ -45,7 +45,7 @@ class SupportServiceImplTest {
      */
     @Test
     void testRequestWithMalformedEmptyKey() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("", "", "test");
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("", "", "test", null);
         SupportException exception = assertThrows(SupportException.class, () -> supportServiceImpl.sendRequest(this.dummySupportRequest()));
         assertEquals("secret key byte array cannot be null or empty.", exception.getMessage());
     }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -22,7 +22,7 @@ class SupportServiceImplTest {
     @Test
     void testSendRequest(){
         FreeMarkerConfigurer freeMarkerConfigurer = freemarkerClassLoaderConfig();
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", freeMarkerConfigurer);
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", "redirectUrl", freeMarkerConfigurer);
         String url = supportServiceImpl.sendRequest(this.dummySupportRequest());
         assertNotNull(url);
         assertTrue(url.contains("jwt"));
@@ -35,7 +35,7 @@ class SupportServiceImplTest {
     @Test
     void testSendRequestThrowException() {
         FreeMarkerConfigurer freeMarkerConfigurer = Mockito.mock(FreeMarkerConfigurer.class);
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", freeMarkerConfigurer);
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "test-organization", "redirectUrl", freeMarkerConfigurer);
         Exception exception = assertThrows(Exception.class, () -> supportServiceImpl.sendRequest(this.dummySupportRequest()));
         assertEquals("Impossible to retrieve zendesk form template", exception.getMessage());
     }
@@ -46,7 +46,7 @@ class SupportServiceImplTest {
     @Test
     void testSendRequestWithProductId() {
         FreeMarkerConfigurer freeMarkerConfigurer = freemarkerClassLoaderConfig();
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", freeMarkerConfigurer);
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("w90kAW1FIIJaMuWbKGyd8GfDkv45tVPiyYvrdLADsK2ANX26", "", "", "redirectUrl", freeMarkerConfigurer);
         SupportRequest supportRequest = this.dummySupportRequest();
         supportRequest.setProductId("prodottoDiTest");
         String url = supportServiceImpl.sendRequest(supportRequest);
@@ -60,7 +60,7 @@ class SupportServiceImplTest {
      */
     @Test
     void testRequestWithMalformedEmptyKey() {
-        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("", "", "test", null);
+        SupportServiceImpl supportServiceImpl = new SupportServiceImpl("", "", "test", "redirectUrl", null);
         SupportException exception = assertThrows(SupportException.class, () -> supportServiceImpl.sendRequest(this.dummySupportRequest()));
         assertEquals("secret key byte array cannot be null or empty.", exception.getMessage());
     }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.dashboard.connector.model.support.SupportResponse;
 import it.pagopa.selfcare.dashboard.core.SupportService;
 import it.pagopa.selfcare.dashboard.web.model.mapper.SupportMapper;
 import it.pagopa.selfcare.dashboard.web.model.support.SupportRequestDto;

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/SupportController.java
@@ -33,10 +33,10 @@ public class SupportController {
     }
 
     @Tag(name = "external-v2")
-    @PostMapping
+    @PostMapping(produces = MediaType.TEXT_HTML_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.dashboard.support.api.sendRequest}")
-    public SupportResponse sendSupportRequest(@RequestBody @Valid SupportRequestDto supportRequestDto,
+    public String sendSupportRequest(@RequestBody @Valid SupportRequestDto supportRequestDto,
                                               Authentication authentication) {
         log.trace("sendSupportRequest start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "sendSupportRequest request = {}", supportRequestDto);
@@ -44,6 +44,6 @@ public class SupportController {
         String url = supportService.sendRequest(supportMapper.toZendeskRequest(supportRequestDto, selfCareUser));
         log.debug("sendSupportRequest result = {}", url);
         log.trace("sendSupportRequest end");
-        return SupportResponse.builder().redirectUrl(url).build();
+        return url;
     }
 }

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/SupportControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/SupportControllerTest.java
@@ -1,9 +1,7 @@
 package it.pagopa.selfcare.dashboard.web.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.dashboard.connector.model.support.SupportResponse;
 import it.pagopa.selfcare.dashboard.core.SupportService;
 import it.pagopa.selfcare.dashboard.web.model.delegation.DelegationRequestDto;
 import it.pagopa.selfcare.dashboard.web.model.mapper.SupportMapper;
@@ -27,12 +25,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ContextConfiguration(classes = {DelegationController.class})
+@ContextConfiguration(classes = {SupportController.class})
 @ExtendWith(MockitoExtension.class)
 class SupportControllerTest {
 
@@ -78,17 +75,11 @@ class SupportControllerTest {
                 .build()
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andReturn();
 
-        SupportResponse response = objectMapper.readValue(
-                result.getResponse().getContentAsString(),
-                new TypeReference<>() {
-                });
-
+        String response = result.getResponse().getContentAsString();
         assertNotNull(response);
-        assertNotNull(response.getRedirectUrl());
-        assertEquals(response.getRedirectUrl(), redirectUrl);
+
     }
 
     /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Returning an HTML page containing a Form POST with a submit directly to the Zendesk page instead of the URL redirect

#### Motivation and Context

Zendesk didn't want the authentication token to appear in the URL when redirected to their page. For this reason it was thought to carry out the redirect via Form. This change was initially thought to be implemented on the FE side. The problem is that the redirect to the Zendesk page through a Form caused CORS problems. To overcome the problem it was decided to implement the solution on the backend side. A Spring library already implemented on the BE side (FreeMarker) was used which allowed us to return the html page containing the form for the redirection to the Zendesk page.

#### How Has This Been Tested?

The backend dashboard microservice was started locally and the redirect API was invoked, subsequently it was verified that the html page containing the redirect form was returned.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.