### PR TITLE
[SELC-4364] Feat: Added SelfCarePermissionEvaluatorV2 to check Permission using selfcare user API

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -30,3 +30,7 @@ logging:
     it.pagopa.selfcare: ${B4F_DASHBOARD_LOG_LEVEL:DEBUG}
   pattern:
     additional-info: ",%X{X-Client-Ip:-}]"
+
+dashboard:
+  security:
+    connector: ${B4F_DASHBOARD_SECURITY_CONNECTOR:v1}

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
@@ -19,4 +19,6 @@ public interface UserApiConnector {
     void activateUserProduct(String userId, String institutionId, String productId);
 
     void deleteUserProduct(String userId, String institutionId, String productId);
+
+    Boolean hasPermission(String institutionId, String permission, String productId);
 }

--- a/connector/rest/docs/openapi/selfcare-user-docs.json
+++ b/connector/rest/docs/openapi/selfcare-user-docs.json
@@ -5,6 +5,63 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/authorize/{institutionId}": {
+      "get": {
+        "tags": [
+          "User Permission Controller"
+        ],
+        "summary": "Get permission for a user in an institution",
+        "parameters": [
+          {
+            "name": "institutionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PermissionTypeEnum"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
     "/institutions/{institutionId}/products/{productId}/createdAt": {
       "put": {
         "tags": [
@@ -296,6 +353,40 @@
                   }
                 }
               }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "User Controller"
+        ],
+        "summary": "Create or Update user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
             }
           },
           "401": {
@@ -945,6 +1036,32 @@
         ],
         "type": "string"
       },
+      "CreateUserDto": {
+        "required": [
+          "institutionId",
+          "user",
+          "product"
+        ],
+        "type": "object",
+        "properties": {
+          "institutionId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "institutionDescription": {
+            "type": "string"
+          },
+          "institutionRootName": {
+            "type": "string"
+          }
+        }
+      },
       "Env": {
         "enum": [
           "ROOT",
@@ -1059,6 +1176,35 @@
         ],
         "type": "string"
       },
+      "PermissionTypeEnum": {
+        "enum": [
+          "ADMIN",
+          "ANY"
+        ],
+        "type": "string"
+      },
+      "Product": {
+        "required": [
+          "productId",
+          "role"
+        ],
+        "type": "object",
+        "properties": {
+          "productId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/PartyRole"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "productRole": {
+            "type": "string"
+          }
+        }
+      },
       "QueueEvent": {
         "enum": [
           "ADD",
@@ -1073,6 +1219,37 @@
         "type": "object",
         "properties": {
           "fiscalCode": {
+            "pattern": "\\S",
+            "type": "string"
+          }
+        }
+      },
+      "User": {
+        "required": [
+          "familyName",
+          "fiscalCode",
+          "name",
+          "institutionEmail"
+        ],
+        "type": "object",
+        "properties": {
+          "birthDate": {
+            "type": "string"
+          },
+          "familyName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "fiscalCode": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "institutionEmail": {
+            "minLength": 1,
             "type": "string"
           }
         }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -5,18 +5,18 @@ import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.connector.rest.client.UserApiRestClient;
+import it.pagopa.selfcare.dashboard.connector.rest.client.UserPermissionRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.model.mapper.InstitutionMapper;
 import it.pagopa.selfcare.dashboard.connector.rest.model.mapper.UserMapper;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.OnboardedProductState;
+import it.pagopa.selfcare.user.generated.openapi.v1.dto.PermissionTypeEnum;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.SearchUserDto;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserProductsResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import static it.pagopa.selfcare.dashboard.connector.model.institution.RelationshipState.*;
 
@@ -27,6 +27,7 @@ public class UserConnectorImpl implements UserApiConnector {
 
 
     private final UserApiRestClient userApiRestClient;
+    private final UserPermissionRestClient userPermissionRestClient;
     private final InstitutionMapper institutionMapper;
 
     private final UserMapper userMapper;
@@ -45,6 +46,19 @@ public class UserConnectorImpl implements UserApiConnector {
                 .toList();
         log.debug("getUserProducts result = {}", result);
         log.trace("getUserProducts end");
+        return result;
+    }
+
+    @Override
+    public Boolean hasPermission(String institutionId, String permission, String productId) {
+        log.trace("permissionInstitutionIdPermissionGet start");
+        log.debug("permissionInstitutionIdPermissionGet institutionId = {}, permission = {}, productId = {}", institutionId, permission, productId);
+
+        PermissionTypeEnum permissionTypeEnum = PermissionTypeEnum.fromValue(permission);
+        Boolean result = userPermissionRestClient._authorizeInstitutionIdGet(institutionId, permissionTypeEnum, productId).getBody();
+
+        log.debug("permissionInstitutionIdPermissionGet result = {}", result);
+        log.trace("permissionInstitutionIdPermissionGet end");
         return result;
     }
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserPermissionRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/client/UserPermissionRestClient.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.dashboard.connector.rest.client;
+
+import it.pagopa.selfcare.user.generated.openapi.v1.api.UserPermissionControllerApi;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "${rest-client.user-permission.serviceCode}", url = "${rest-client.user-ms.base-url}")
+public interface UserPermissionRestClient extends UserPermissionControllerApi {
+
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/config/UserPermissionRestClientConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/config/UserPermissionRestClientConfig.java
@@ -1,0 +1,15 @@
+package it.pagopa.selfcare.dashboard.connector.rest.config;
+
+import it.pagopa.selfcare.commons.connector.rest.config.RestClientBaseConfig;
+import it.pagopa.selfcare.dashboard.connector.rest.client.UserPermissionRestClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@Import(RestClientBaseConfig.class)
+@EnableFeignClients(clients = UserPermissionRestClient.class)
+@PropertySource("classpath:config/user-rest-client.properties")
+public class UserPermissionRestClientConfig {
+}

--- a/connector/rest/src/main/resources/config/user-rest-client.properties
+++ b/connector/rest/src/main/resources/config/user-rest-client.properties
@@ -1,5 +1,6 @@
 rest-client.user-ms.base-url=${SELFCARE_USER_URL:http://localhost:8080}
 rest-client.user-ms.serviceCode=user-ms
+rest-client.user-permission.serviceCode=user-permission
 feign.client.config.user-ms.connectTimeout=${SELFCARE_USER_REST_CLIENT_CONNECT_TIMEOUT:${REST_CLIENT_CONNECT_TIMEOUT:5000}}
 feign.client.config.user-ms.readTimeout=${SELFCARE_USER_REST_CLIENT_READ_TIMEOUT:${REST_CLIENT_READ_TIMEOUT:5000}}
 feign.client.config.user-ms.loggerLevel=${SELFCARE_USER_REST_CLIENT_LOGGER_LEVEL:${REST_CLIENT_LOGGER_LEVEL:FULL}}

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/MethodSecurityConfig.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/MethodSecurityConfig.java
@@ -1,7 +1,10 @@
 package it.pagopa.selfcare.dashboard.web.config;
 
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
+import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
 import it.pagopa.selfcare.dashboard.web.security.SelfCarePermissionEvaluator;
+import it.pagopa.selfcare.dashboard.web.security.SelfCarePermissionEvaluatorV2;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
@@ -13,15 +16,25 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
     private final MsCoreConnector msCoreConnector;
+    private final UserApiConnector userApiConnector;
+    private final String securityConnectorType;
 
-    public MethodSecurityConfig(MsCoreConnector msCoreConnector) {
+    public MethodSecurityConfig(MsCoreConnector msCoreConnector,
+                                UserApiConnector userApiConnector,
+                                @Value("${dashboard.security.connector}") String securityConnectorType) {
         this.msCoreConnector = msCoreConnector;
+        this.userApiConnector = userApiConnector;
+        this.securityConnectorType = securityConnectorType;
     }
 
     @Override
     protected MethodSecurityExpressionHandler createExpressionHandler() {
         DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
-        expressionHandler.setPermissionEvaluator(new SelfCarePermissionEvaluator(msCoreConnector));
+        if(securityConnectorType.equalsIgnoreCase("v1")) {
+            expressionHandler.setPermissionEvaluator(new SelfCarePermissionEvaluator(msCoreConnector));
+        }else {
+            expressionHandler.setPermissionEvaluator(new SelfCarePermissionEvaluatorV2(userApiConnector));
+        }
         return expressionHandler;
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/PartyAuthoritiesRetriever.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/PartyAuthoritiesRetriever.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.model.auth.AuthInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +22,10 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(
+        value="dashboard.security.connector",
+        havingValue = "v1",
+        matchIfMissing = true)
 class PartyAuthoritiesRetriever implements AuthoritiesRetriever {
 
     private final MsCoreConnector msCoreConnector;

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2.java
@@ -1,0 +1,61 @@
+package it.pagopa.selfcare.dashboard.web.security;
+
+import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
+import it.pagopa.selfcare.dashboard.web.model.InstitutionResource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+
+@Slf4j
+public class SelfCarePermissionEvaluatorV2 implements PermissionEvaluator {
+    private final UserApiConnector userApiConnector;
+
+    public SelfCarePermissionEvaluatorV2(UserApiConnector userApiConnector) {
+        this.userApiConnector = userApiConnector;
+    }
+
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        log.trace("hasPermission start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "hasPermission authentication = {}, targetDomainObject = {}, permission = {}", authentication, targetDomainObject, permission);
+
+        Assert.notNull(authentication, "An authentication is required");
+        Assert.notNull(permission, "A permission is required");
+        boolean result = false;
+        if (targetDomainObject != null && ProductAclDomain.class.equals(targetDomainObject.getClass())) {
+            ProductAclDomain productAclDomain = (ProductAclDomain) targetDomainObject;
+            Assert.notNull(productAclDomain.getInstitutionId(), "InstitutionId is required");
+            result = userApiConnector.hasPermission(productAclDomain.getInstitutionId(), permission.toString(), productAclDomain.getProductId());
+        }
+        log.debug("hasPermission result = {}", result);
+        log.trace("hasPermission end");
+        return result;
+    }
+
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+        log.trace("hasPermission start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "hasPermission authentication = {}, targetId = {}, targetType = {}, permission = {}", authentication, targetId, targetType, permission);
+
+        Assert.notNull(authentication, "An authentication is required");
+        Assert.notNull(targetType, "A targetType is required");
+        Assert.notNull(permission, "A permission is required");
+
+        boolean result = false;
+
+        if (targetId != null && InstitutionResource.class.getSimpleName().equals(targetType)) {
+            Assert.notNull(targetId.toString(), "InstitutionId is required");
+            result = userApiConnector.hasPermission(targetId.toString(), permission.toString(), null);
+        }
+        log.debug("hasPermission result = {}", result);
+        log.trace("hasPermission end");
+        return result;
+    }
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2.java
@@ -21,31 +21,30 @@ public class SelfCarePermissionEvaluatorV2 implements PermissionEvaluator {
 
     @Override
     public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
-        log.trace("hasPermission start");
+        log.info("start check Permission");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "hasPermission authentication = {}, targetDomainObject = {}, permission = {}", authentication, targetDomainObject, permission);
 
-        Assert.notNull(authentication, "An authentication is required");
-        Assert.notNull(permission, "A permission is required");
+        Assert.notNull(permission, "A permission type is required");
         boolean result = false;
+
         if (targetDomainObject != null && ProductAclDomain.class.equals(targetDomainObject.getClass())) {
             ProductAclDomain productAclDomain = (ProductAclDomain) targetDomainObject;
             Assert.notNull(productAclDomain.getInstitutionId(), "InstitutionId is required");
             result = userApiConnector.hasPermission(productAclDomain.getInstitutionId(), permission.toString(), productAclDomain.getProductId());
         }
-        log.debug("hasPermission result = {}", result);
-        log.trace("hasPermission end");
+
+        log.debug("check Permission result = {}", result);
+        log.trace("check Permission end");
         return result;
     }
 
 
     @Override
     public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
-        log.trace("hasPermission start");
+        log.trace("check Permission start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "hasPermission authentication = {}, targetId = {}, targetType = {}, permission = {}", authentication, targetId, targetType, permission);
 
-        Assert.notNull(authentication, "An authentication is required");
-        Assert.notNull(targetType, "A targetType is required");
-        Assert.notNull(permission, "A permission is required");
+        Assert.notNull(permission, "A permission type is required");
 
         boolean result = false;
 
@@ -53,8 +52,9 @@ public class SelfCarePermissionEvaluatorV2 implements PermissionEvaluator {
             Assert.notNull(targetId.toString(), "InstitutionId is required");
             result = userApiConnector.hasPermission(targetId.toString(), permission.toString(), null);
         }
-        log.debug("hasPermission result = {}", result);
-        log.trace("hasPermission end");
+
+        log.debug("check Permission result = {}", result);
+        log.trace("check Permission end");
         return result;
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2Test.java
@@ -1,0 +1,220 @@
+package it.pagopa.selfcare.dashboard.web.security;
+
+import it.pagopa.selfcare.commons.base.security.ProductGrantedAuthority;
+import it.pagopa.selfcare.commons.base.security.SelfCareGrantedAuthority;
+import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
+import it.pagopa.selfcare.dashboard.web.model.InstitutionResource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static it.pagopa.selfcare.commons.base.security.PartyRole.MANAGER;
+import static it.pagopa.selfcare.commons.base.security.SelfCareAuthority.ADMIN;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {SelfCarePermissionEvaluatorV2.class})
+class SelfCarePermissionEvaluatorV2Test {
+
+    @MockBean
+    UserApiConnector userApiConnector;
+
+    @Autowired
+    SelfCarePermissionEvaluatorV2 permissionEvaluator;
+
+
+    @Test
+    void hasPermission_withObjectDomain_nullAuth() {
+        // given
+        Object targetDomainObject = new Object();
+        Object permission = new Object();
+        // when
+        Executable executable = () -> permissionEvaluator.hasPermission(null, targetDomainObject, permission);
+        // then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals("An authentication is required", e.getMessage());
+    }
+
+
+    @Test
+    void hasPermission_withObjectDomain_nullPermission() {
+        // given
+        Authentication authentication = new TestingAuthenticationToken(null, null);
+        Object targetDomainObject = new Object();
+        // when
+        Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetDomainObject, null);
+        // then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals("A permission is required", e.getMessage());
+    }
+
+
+    @Test
+    void hasPermission_withObjectDomain_nullTargetDomainObject() {
+        // given
+        Authentication authentication = new TestingAuthenticationToken(null, null);
+        Object permission = new Object();
+        // when
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, null, permission);
+        // then
+        assertFalse(hasPermission);
+    }
+
+
+    @Test
+    void hasPermission_withObjectDomain_notPermitted_noAuthority() {
+        // given
+        String institutionId = "institutionId";
+        Object targetDomainObject = new ProductAclDomain(institutionId, "notPermittedProductId");
+        Object permission = new Object();
+        List<ProductGrantedAuthority> roleOnProducts = List.of(new ProductGrantedAuthority(MANAGER, "productRole", "productId"));
+        List<GrantedAuthority> authorities = List.of(new SelfCareGrantedAuthority(institutionId, roleOnProducts));
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", authorities);
+        // when
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetDomainObject, permission);
+        // then
+        assertFalse(hasPermission);
+    }
+
+    @Test
+    void hasPermission_withObjectDomain_notPermitted_invalidRole() {
+        // given
+        String institutionId = "institutionId";
+        String productId = "productId";
+        Object targetDomainObject = new ProductAclDomain(institutionId, productId);
+        String permission = "ADMIN";
+        when(userApiConnector.hasPermission(institutionId, permission, productId)).thenReturn(false);
+        // when
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", permission);
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetDomainObject, permission);
+        // then
+        assertFalse(hasPermission);
+    }
+
+    @Test
+    void hasPermission_withObjectDomain_permitted() {
+        // given
+        String institutionId = "institutionId";
+        String productId = "productId";
+        Object targetDomainObject = new ProductAclDomain(institutionId, productId);
+        String permission = "ADMIN";
+
+        when(userApiConnector.hasPermission(institutionId, permission, productId)).thenReturn(true);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", permission);
+        // when
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetDomainObject, permission);
+        // then
+        assertTrue(hasPermission);
+    }
+
+    @Test
+    void hasPermission_withObjectDomain_anyPermittedAsAdmin() {
+        // given
+        String institutionId = "institutionId";
+        String productId = "productId";
+        Object targetDomainObject = new ProductAclDomain(institutionId, productId);
+        String permission = "ANY";
+        when(userApiConnector.hasPermission(institutionId, permission, productId)).thenReturn(true);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", permission);
+        // when
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetDomainObject, permission);
+        // then
+        assertTrue(hasPermission);
+    }
+
+
+    @Test
+    void hasPermission_withTargetId_nullAuth() {
+        // given
+        Serializable targetId = "targetId";
+        String targetType = "targetType";
+        Object permission = new Object();
+        // when
+        Executable executable = () -> permissionEvaluator.hasPermission(null, targetId, targetType, permission);
+        // then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals("An authentication is required", e.getMessage());
+    }
+
+
+    @Test
+    void hasPermission_withTargetId_nullTargetType() {
+        // given
+        Authentication authentication = new TestingAuthenticationToken(null, null);
+        Serializable targetId = "targetId";
+        Object permission = new Object();
+        // when
+        Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetId, null, permission);
+        // then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals("A targetType is required", e.getMessage());
+    }
+
+
+    @Test
+    void hasPermission_withTargetId_nullPermission() {
+        // given
+        Authentication authentication = new TestingAuthenticationToken(null, null);
+        Serializable targetId = "targetId";
+        String targetType = "targetType";
+        // when
+        Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetId, targetType, null);
+        // then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals("A permission is required", e.getMessage());
+    }
+
+
+    @Test
+    void hasPermission_withTargetId_nullTargetId() {
+        // given
+        Authentication authentication = new TestingAuthenticationToken(null, null);
+        String targetType = "targetType";
+        Object permission = new Object();
+        // when
+        boolean result = permissionEvaluator.hasPermission(authentication, null, targetType, permission);
+        // then
+        assertFalse(result);
+    }
+
+
+    @Test
+    void hasPermission_withTargetId_targetTypeInstitutionResource_notPermitted_noAuthority() {
+        // given
+        Serializable targetId = "notPermittedInstitutionId";
+        String targetType = InstitutionResource.class.getSimpleName();
+        String permission = "ADMIN";
+        String institutionId = "institutionId";
+        when(userApiConnector.hasPermission(institutionId, permission, null)).thenReturn(false);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", permission);
+
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetId, targetType, permission);
+        // then
+        assertFalse(hasPermission);
+    }
+
+    @Test
+    void hasPermission_withTargetId_targetTypeInstitutionResource_permitted() {
+        // given
+        Serializable targetId = "institutionId";
+        String targetType = InstitutionResource.class.getSimpleName();
+        String  permission = ADMIN.toString();
+        when(userApiConnector.hasPermission(targetId.toString(), permission, null)).thenReturn(true);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", "password", permission);
+        boolean hasPermission = permissionEvaluator.hasPermission(authentication, targetId, targetType, permission);
+        // then
+        assertTrue(hasPermission);
+    }
+
+}

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/SelfCarePermissionEvaluatorV2Test.java
@@ -33,20 +33,6 @@ class SelfCarePermissionEvaluatorV2Test {
     @Autowired
     SelfCarePermissionEvaluatorV2 permissionEvaluator;
 
-
-    @Test
-    void hasPermission_withObjectDomain_nullAuth() {
-        // given
-        Object targetDomainObject = new Object();
-        Object permission = new Object();
-        // when
-        Executable executable = () -> permissionEvaluator.hasPermission(null, targetDomainObject, permission);
-        // then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        assertEquals("An authentication is required", e.getMessage());
-    }
-
-
     @Test
     void hasPermission_withObjectDomain_nullPermission() {
         // given
@@ -56,7 +42,7 @@ class SelfCarePermissionEvaluatorV2Test {
         Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetDomainObject, null);
         // then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        assertEquals("A permission is required", e.getMessage());
+        assertEquals("A permission type is required", e.getMessage());
     }
 
 
@@ -133,35 +119,6 @@ class SelfCarePermissionEvaluatorV2Test {
         assertTrue(hasPermission);
     }
 
-
-    @Test
-    void hasPermission_withTargetId_nullAuth() {
-        // given
-        Serializable targetId = "targetId";
-        String targetType = "targetType";
-        Object permission = new Object();
-        // when
-        Executable executable = () -> permissionEvaluator.hasPermission(null, targetId, targetType, permission);
-        // then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        assertEquals("An authentication is required", e.getMessage());
-    }
-
-
-    @Test
-    void hasPermission_withTargetId_nullTargetType() {
-        // given
-        Authentication authentication = new TestingAuthenticationToken(null, null);
-        Serializable targetId = "targetId";
-        Object permission = new Object();
-        // when
-        Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetId, null, permission);
-        // then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        assertEquals("A targetType is required", e.getMessage());
-    }
-
-
     @Test
     void hasPermission_withTargetId_nullPermission() {
         // given
@@ -172,7 +129,7 @@ class SelfCarePermissionEvaluatorV2Test {
         Executable executable = () -> permissionEvaluator.hasPermission(authentication, targetId, targetType, null);
         // then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
-        assertEquals("A permission is required", e.getMessage());
+        assertEquals("A permission type is required", e.getMessage());
     }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added SelfCarePermissionEvaluatorV2 to check Permission using selfcare user API
- Added hasPermission method implementation in UserConnectorImpl
- Added condition in MethodSecurityConfig to load, as permissionEvaluator on MethodSecurityExpressionHandler, SelfCarePermissionEvaluator or SelfCarePermissionEvaluatorV2
- Added properties and condition to enable or disable PartyAuthoritiesRetrieved.

#### Motivation and Context
In order to move all authorization-related logic for API access to selfcare user, dashboard bff will no longer handle this logic but will instead call an API on selfcare user that will return the corresponding boolean for allowed or deny.


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.