### PR TITLE
[SELC-4456] feat: added endpoint to update user invoking user-ms

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -3574,6 +3574,78 @@
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]
+      },
+      "put" : {
+        "tags" : [ "user" ],
+        "summary" : "updateUser",
+        "description" : "Update previously added user",
+        "operationId" : "updateUserUsingPUT_1",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "User's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "institutionId",
+          "in" : "query",
+          "description" : "Institution's unique internal identifier",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateUserDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
       }
     },
     "/v2/{userId}" : {

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
@@ -1,10 +1,10 @@
 package it.pagopa.selfcare.dashboard.connector.api;
 
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 
 import java.util.List;
-
 
 public interface UserApiConnector {
 
@@ -21,4 +21,6 @@ public interface UserApiConnector {
     void deleteUserProduct(String userId, String institutionId, String productId);
 
     Boolean hasPermission(String institutionId, String permission, String productId);
+
+    void updateUser(String userId, String institutionId, MutableUserFieldsDto userDto);
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.dashboard.connector.rest;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.connector.rest.client.UserApiRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.UserPermissionRestClient;
@@ -12,12 +13,12 @@ import it.pagopa.selfcare.user.generated.openapi.v1.dto.OnboardedProductState;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.PermissionTypeEnum;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.SearchUserDto;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserProductsResponse;
-import it.pagopa.selfcare.user.generated.openapi.v1.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 
 import static it.pagopa.selfcare.dashboard.connector.model.institution.RelationshipState.*;
 
@@ -26,13 +27,10 @@ import static it.pagopa.selfcare.dashboard.connector.model.institution.Relations
 @RequiredArgsConstructor
 public class UserConnectorImpl implements UserApiConnector {
 
-
     private final UserApiRestClient userApiRestClient;
     private final UserPermissionRestClient userPermissionRestClient;
     private final InstitutionMapper institutionMapper;
-
     private final UserMapper userMapper;
-
 
     @Override
     public List<InstitutionInfo> getUserProducts(String userId) {
@@ -106,5 +104,13 @@ public class UserConnectorImpl implements UserApiConnector {
         log.debug("delete userId = {}, institutionId = {}", userId, institutionId);
         userApiRestClient._usersIdInstitutionInstitutionIdProductProductIdStatusPut(userId, institutionId, productId, OnboardedProductState.DELETED);
         log.trace("delete end");
+    }
+
+    @Override
+    public void updateUser(String userId, String institutionId, MutableUserFieldsDto userDto) {
+        log.trace("updateUser start");
+        log.debug("updateUser userId = {}, institutionId = {}, userDto = {}", userId, institutionId, userDto);
+        userApiRestClient._usersIdUserRegistryPut(userId, institutionId, userMapper.toMutableUserFieldsDto(userDto));
+        log.trace("updateUser end");
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/UserMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/UserMapper.java
@@ -41,7 +41,7 @@ public interface UserMapper {
         if(workContactMap != null && !workContactMap.isEmpty()) {
             workContactMap.forEach((s, workContact) -> resourceMap.put(s, WorkContactResource.builder().email(toCertifiableFieldResourceOfString(workContact.getEmail())).build()));
         }
-        return resourceMap;
+        return null;
     }
 
     User toUser(UserDetailResponse response);

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.connector.rest;
 
 import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.connector.rest.client.UserApiRestClient;
 import it.pagopa.selfcare.dashboard.connector.rest.client.UserPermissionRestClient;
@@ -196,6 +197,20 @@ class UserConnectorImplTest {
         //then
         assertNotNull(result);
         assertEquals(false, result);
+    }
+
+    @Test
+    void update() {
+        // given
+        final String userId = "userId";
+        final String institutionId = "institutionId";
+        final var user = new MutableUserFieldsDto();
+        // when
+        userConnector.updateUser(userId, institutionId, user);
+        // then
+        verify(userApiRestClient, times(1))
+                ._usersIdUserRegistryPut(userId, institutionId, it.pagopa.selfcare.user.generated.openapi.v1.dto.MutableUserFieldsDto.builder().build());
+        verifyNoMoreInteractions(userApiRestClient);
     }
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2Service.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2Service.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.dashboard.core;
 
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 
 import java.util.Collection;
@@ -18,6 +19,8 @@ public interface UserV2Service {
     User getUserById(String userId);
 
     User searchUserByFiscalCode(String fiscalCode);
+
+    void updateUser(String id, String institutionId, MutableUserFieldsDto userDto);
 
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
@@ -3,13 +3,18 @@ package it.pagopa.selfcare.dashboard.core;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
+import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
 import java.util.Collection;
+import java.util.Objects;
 
 
 @Slf4j
@@ -74,6 +79,21 @@ public class UserV2ServiceImpl implements UserV2Service {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "searchByFiscalCode user = {}", user);
         log.trace("searchByFiscalCode end");
         return user;
+    }
+
+    @Override
+    public void updateUser(String id, String institutionId, MutableUserFieldsDto userDto) {
+        log.trace("updateUser start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "updateUser id = {}, institutionId = {}, userDto = {}", id, institutionId, userDto);
+        Assert.notNull(id, "UUID is required");
+        Assert.hasText(institutionId, "An institutionId is required");
+        Assert.notNull(userDto, "A userDto is required");
+        final Institution institution = msCoreConnector.getInstitution(institutionId);
+        if (Objects.isNull(institution)) {
+            throw new ResourceNotFoundException("There is no institution for given institutionId");
+        }
+        userApiConnector.updateUser(id, institutionId, userDto);
+        log.trace("updateUser end");
     }
 
 }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
@@ -3,10 +3,15 @@ package it.pagopa.selfcare.dashboard.core;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.api.UserApiConnector;
 import it.pagopa.selfcare.dashboard.connector.api.UserRegistryConnector;
+import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.MutableUserFieldsDto;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
+import it.pagopa.selfcare.dashboard.connector.model.user.WorkContact;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -14,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static org.junit.jupiter.api.Assertions.*;
@@ -123,5 +129,41 @@ class UserV2ServiceImplTest {
         assertNotNull(result);
         assertEquals(user, result);
         verify(userApiConnector, times(1)).searchByFiscalCode(fiscalCode);
+    }
+
+    @Test
+    void updateUser() {
+        //given
+        final String institutionId = "institutionId";
+        final String userId = "userId";
+        final MutableUserFieldsDto user = mockInstance(new MutableUserFieldsDto(), "setWorkContacts");
+        WorkContact workContact = mockInstance(new WorkContact());
+        user.setWorkContacts(Map.of(institutionId, workContact));
+        Institution institutionMock = mockInstance(new Institution());
+        when(msCoreConnectorMock.getInstitution(Mockito.anyString()))
+                .thenReturn(institutionMock);
+        //when
+        Executable executable = () -> userService.updateUser(userId, institutionId, user);
+        //then
+        assertDoesNotThrow(executable);
+        verify(msCoreConnectorMock, times(1))
+                .getInstitution(institutionId);
+        verify(userApiConnector, times(1))
+                .updateUser(userId, institutionId, user);
+        verifyNoMoreInteractions(userConnectorMock, msCoreConnectorMock);
+    }
+
+    @Test
+    void updateUser_nullInstitution() {
+        //given
+        final String institutionId = "institutionId";
+        final String userId = "userId";
+        final MutableUserFieldsDto user = mockInstance(new MutableUserFieldsDto(), "setWorkContacts");
+        //when
+        Executable executable = () -> userService.updateUser(userId, institutionId, user);
+        //then
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, executable);
+        assertEquals("There is no institution for given institutionId", exception.getMessage());
+        verifyNoInteractions(userApiConnector);
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserController.java
@@ -69,13 +69,13 @@ public class UserController {
     @ApiOperation(value = "", notes = "${swagger.dashboard.user.api.updateUserById}")
     public void updateUser(@ApiParam("${swagger.dashboard.user.model.id}")
                            @PathVariable("id")
-                                   UUID id,
+                           UUID id,
                            @ApiParam("${swagger.dashboard.institutions.model.id}")
                            @RequestParam(value = "institutionId")
-                                   String institutionId,
+                           String institutionId,
                            @RequestBody
                            @Valid
-                                   UpdateUserDto updateUserDto) {
+                           UpdateUserDto updateUserDto) {
         log.trace("updateUser start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "id = {}, institutionId = {}, userDto = {}", id, institutionId, updateUserDto);
         userService.updateUser(id, institutionId, UserMapper.fromUpdateUser(updateUserDto, institutionId));

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserV2Controller.java
@@ -14,6 +14,7 @@ import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.core.UserV2Service;
 import it.pagopa.selfcare.dashboard.web.InstitutionBaseResource;
 import it.pagopa.selfcare.dashboard.web.model.SearchUserDto;
+import it.pagopa.selfcare.dashboard.web.model.UpdateUserDto;
 import it.pagopa.selfcare.dashboard.web.model.mapper.InstitutionResourceMapper;
 import it.pagopa.selfcare.dashboard.web.model.mapper.UserMapperV2;
 import it.pagopa.selfcare.dashboard.web.model.user.UserResource;
@@ -74,7 +75,6 @@ public class UserV2Controller {
         log.trace("suspendUser end");
 
     }
-
 
     @PostMapping(value = "/{userId}/activate")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -138,5 +138,23 @@ public class UserV2Controller {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "searchByFiscalCode user = {}", user);
         log.trace("searchByFiscalCode end");
         return userMapperV2.toUserResource(user);
+    }
+
+    @PutMapping(value = "/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "", notes = "${swagger.dashboard.user.api.updateUserById}")
+    public void updateUser(@ApiParam("${swagger.dashboard.user.model.id}")
+                           @PathVariable("id")
+                           String userId,
+                           @ApiParam("${swagger.dashboard.institutions.model.id}")
+                           @RequestParam(value = "institutionId")
+                           String institutionId,
+                           @RequestBody
+                           @Valid
+                           UpdateUserDto updateUserDto) {
+        log.trace("updateUser start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "userId = {}, institutionId = {}, userDto = {}", userId, institutionId, updateUserDto);
+        userService.updateUser(userId, institutionId, userMapperV2.fromUpdateUser(institutionId, updateUserDto));
+        log.trace("updateUser end");
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/UserMapperV2.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/UserMapperV2.java
@@ -1,10 +1,44 @@
 package it.pagopa.selfcare.dashboard.web.model.mapper;
 
-import it.pagopa.selfcare.dashboard.connector.model.user.User;
+import it.pagopa.selfcare.dashboard.connector.model.user.*;
+import it.pagopa.selfcare.dashboard.web.model.UpdateUserDto;
 import it.pagopa.selfcare.dashboard.web.model.user.UserResource;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.Map;
+import java.util.Objects;
 
 @Mapper(componentModel = "spring")
 public interface UserMapperV2 {
+
     UserResource toUserResource(User model);
+
+    @Mapping(source = "userDto.name", target = "name", qualifiedByName = "mapCertifiedField")
+    @Mapping(source = "userDto.email", target = "email", qualifiedByName = "mapCertifiedField")
+    @Mapping(target = "workContacts", expression = "java(getEmail(userDto, institutionId))")
+    @Mapping(source = "userDto.surname", target = "familyName", qualifiedByName = "mapCertifiedField")
+    MutableUserFieldsDto fromUpdateUser(String institutionId, UpdateUserDto userDto);
+
+    @Named("mapCertifiedField")
+    default <T> CertifiedField<T> mapCertifiedField(T certifiedField) {
+        CertifiedField<T> resource = null;
+        if (certifiedField != null) {
+            resource = new CertifiedField<>();
+            resource.setValue(certifiedField);
+            resource.setCertification(Certification.NONE);
+        }
+        return resource;
+    }
+
+    @Named("getEmail")
+    default Map getEmail(UpdateUserDto userDto, String institutionId) {
+        if (Objects.nonNull(userDto) && Objects.nonNull(institutionId)) {
+            WorkContact contact = new WorkContact();
+            contact.setEmail(CertifiedFieldMapper.map(userDto.getEmail()));
+            return Map.of(institutionId, contact);
+        }
+        return Map.of();
+    }
 }


### PR DESCRIPTION
#### List of Changes

Added endpoint to update user invoking user-ms

#### Motivation and Context

In order to invoke the new microservice user, a new enpoint has been added to interact with rest client for user-ms

#### How Has This Been Tested?

I have run the microservice locally and tested the specific API **PUT** **/users/{id}**
