### PR TITLE
[SELC-4588] Fix: refactor userRole value according to ADMIN and LIMITED

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/InstitutionResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/InstitutionResourceMapper.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.dashboard.web.model.mapper;
 
+import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import it.pagopa.selfcare.commons.base.security.SelfCareGrantedAuthority;
 import it.pagopa.selfcare.dashboard.connector.model.institution.*;
@@ -12,6 +13,7 @@ import org.mapstruct.Named;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +28,7 @@ public interface InstitutionResourceMapper {
     @Mapping(target = "userRole", expression = "java(toUserRole(model.getId(), model.getStatus()))")
     InstitutionBaseResource toResource(InstitutionInfo model);
 
+    @Mapping(target = "userRole", expression = "java(toUserRole(model.getUserRole()))")
     InstitutionBaseResource toResource(InstitutionBase model);
 
     @Mapping(target = "name", source = "description")
@@ -69,6 +72,14 @@ public interface InstitutionResourceMapper {
 
         }
         return userRole;
+    }
+
+    @Named("toUserRole")
+    default String toUserRole(String userRole) {
+        if(StringUtils.hasText(userRole)){
+            return PartyRole.valueOf(userRole).getSelfCareAuthority().toString();
+        }
+        return null;
     }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
@@ -98,6 +98,7 @@ class InstitutionV2ControllerTest {
         when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder(userId).build());
 
         InstitutionBase expectedInstitution = mockInstance(new InstitutionBase());
+        expectedInstitution.setUserRole("MANAGER");
         List<InstitutionBase> expectedInstitutionInfos = new ArrayList<>();
         expectedInstitutionInfos.add(expectedInstitution);
         when(userServiceMock.getInstitutions(userId)).thenReturn(expectedInstitutionInfos);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- refactor userRole value according to ADMIN and LIMITED

#### Motivation and Context

Frontend expects the values for the roles to be ADMIN and Limited, not manager, subdelegate, delegate, and operator, therefore a conversion is necessary before returning the response to the Frontend.

#### How Has This Been Tested?

Local Env

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.