### PR TITLE
[SELC-4551] fix: updated selfcare-user-docs.json removing required params in User Schema

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2268,9 +2268,9 @@
     "/v2/products/{productId}/back-office" : {
       "get" : {
         "tags" : [ "products" ],
-        "summary" : "retrieveProductBackoffice",
+        "summary" : "Service to trigger token exchange and redirect to product's back office URL",
         "description" : "Service to trigger token exchange and redirect to product's back office URL",
-        "operationId" : "retrieveProductBackofficeUsingGET_1",
+        "operationId" : "v2RetrieveProductBackofficeUsingGET",
         "parameters" : [ {
           "name" : "productId",
           "in" : "path",

--- a/connector/rest/docs/openapi/selfcare-user-docs.json
+++ b/connector/rest/docs/openapi/selfcare-user-docs.json
@@ -1424,9 +1424,7 @@
       },
       "User": {
         "required": [
-          "familyName",
           "fiscalCode",
-          "name",
           "institutionEmail"
         ],
         "type": "object",


### PR DESCRIPTION
#### List of Changes

Removed required params (name and familyName) from selfcare-user-docs.json for createUser API

#### Motivation and Context

Name and familyName are not required in order to create the user when the user taxCode already exists in PDV

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):

#### Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.