### PR TITLE
Fix: ProductGrantedAuthority map when user has more productRole on productId

### DIFF
--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
@@ -522,8 +522,14 @@ class ExchangeTokenServiceV2Test {
         onboardedProduct.setProductId(productId);
         onboardedProduct.setProductRole(productRole);
 
+
+        OnboardedProduct onboardedProduct2 = new OnboardedProduct();
+        onboardedProduct2.setRole(MANAGER);
+        onboardedProduct2.setProductId(productId);
+        onboardedProduct2.setProductRole("admin2");
+
         UserInstitution userInstitution = new UserInstitution();
-        userInstitution.setProducts(List.of(onboardedProduct));
+        userInstitution.setProducts(List.of(onboardedProduct, onboardedProduct2));
         Institution institutionMock = mockInstance(new Institution());
         institutionMock.setId(institutionId);
         when( institutionServiceMock.getInstitutionById(any())).thenReturn(institutionMock);
@@ -559,7 +565,7 @@ class ExchangeTokenServiceV2Test {
         assertEquals(institutionInfo.getDescription(), institution.getName());
         assertEquals(institutionId, institution.getId());
         checkNotNullFields(institution, "parentDescription", "rootParent");
-        assertEquals(1, institution.getRoles().size());
+        assertEquals(2, institution.getRoles().size());
         List<String> groups = institution.getGroups();
         assertEquals(pageable.getPageSize(), groups.size());
         assertTrue(groups.stream().allMatch(groupId -> groupId.equals(groupInfo.getId())));


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Fixed ProductGrantedAuthority map when user has more productRole on productId

#### Motivation and Context

User could have multiple productRole on same productId, so we have to construct one ProductGrantedAuthority with list of productRole

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.