### PR TITLE
[SELC-4914] feat: remove taxCode and mode filters from getDelegationsUsingToV2

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -498,25 +498,6 @@
             "type" : "string"
           }
         }, {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "Institution's tax code",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retrieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
-          }
-        }, {
           "name" : "order",
           "in" : "query",
           "description" : "Order to show response NONE, ASC, DESC",
@@ -989,25 +970,6 @@
           "style" : "form",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "Institution's tax code",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retrieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
           }
         }, {
           "name" : "order",

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/GetDelegationParameters.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/GetDelegationParameters.java
@@ -11,7 +11,6 @@ public class GetDelegationParameters {
     private String productId;
     private String search;
     private String taxCode;
-    private String mode;
     private String order;
     private Integer page;
     private Integer size;

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/GetDelegationsMode.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/GetDelegationsMode.java
@@ -1,6 +1,0 @@
-package it.pagopa.selfcare.dashboard.connector.model.delegation;
-
-public enum GetDelegationsMode {
-    FULL,
-    NORMAL
-}

--- a/connector/rest/docs/openapi/api-selfcare-core-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-core-docs.json
@@ -90,16 +90,6 @@
             "type" : "string"
           }
         }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retreieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
-          }
-        }, {
           "name" : "order",
           "in" : "query",
           "description" : "Order to show response NONE, ASC, DESC",
@@ -398,16 +388,6 @@
           "style" : "form",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retreieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
           }
         }, {
           "name" : "order",
@@ -2552,6 +2532,9 @@
           "recipientCode" : {
             "type" : "string"
           },
+          "taxCodeInvoicing" : {
+            "type" : "string"
+          },
           "vatNumber" : {
             "type" : "string"
           }
@@ -2567,6 +2550,9 @@
           "recipientCode" : {
             "type" : "string"
           },
+          "taxCodeInvoicing" : {
+            "type" : "string"
+          },
           "vatNumber" : {
             "type" : "string"
           }
@@ -2580,6 +2566,9 @@
             "type" : "boolean"
           },
           "recipientCode" : {
+            "type" : "string"
+          },
+          "taxCodeInvoicing" : {
             "type" : "string"
           },
           "vatNumber" : {
@@ -3449,9 +3438,6 @@
             "type" : "string"
           },
           "taxCode" : {
-            "type" : "string"
-          },
-          "taxCodeSfe" : {
             "type" : "string"
           },
           "updatedAt" : {

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImpl.java
@@ -119,7 +119,6 @@ class CoreConnectorImpl implements MsCoreConnector {
                 delegationParameters.getProductId(),
                 delegationParameters.getSearch(),
                 delegationParameters.getTaxCode(),
-                delegationParameters.getMode(),
                 delegationParameters.getOrder(),
                 delegationParameters.getPage(),
                 delegationParameters.getSize())
@@ -146,7 +145,6 @@ class CoreConnectorImpl implements MsCoreConnector {
                         delegationParameters.getProductId(),
                         delegationParameters.getSearch(),
                         delegationParameters.getTaxCode(),
-                        delegationParameters.getMode(),
                         delegationParameters.getOrder(),
                         delegationParameters.getPage(),
                         delegationParameters.getSize())

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImplTest.java
@@ -216,7 +216,7 @@ class CoreConnectorImplTest {
         ResponseEntity<List<DelegationResponse>> delegationResponseEntity = new ResponseEntity<>(delegationResponseList, null, HttpStatus.OK);
         GetDelegationParameters parameters = dummyDelegationParameters();
 
-        when(coreDelegationApiRestClient._getDelegationsUsingGET(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(coreDelegationApiRestClient._getDelegationsUsingGET(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(delegationResponseEntity);
 
 
@@ -235,7 +235,7 @@ class CoreConnectorImplTest {
         assertEquals(delegationResponseList.get(0).getBrokerName(), delegationList.get(0).getBrokerName());
 
         verify(coreDelegationApiRestClient, times(1))
-                ._getDelegationsUsingGET(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getMode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
+                ._getDelegationsUsingGET(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
         verifyNoMoreInteractions(coreDelegationApiRestClient);
     }
 
@@ -247,7 +247,7 @@ class CoreConnectorImplTest {
 
         when(delegationResponseEntity.getBody()).thenReturn(null);
 
-        when(coreDelegationApiRestClient._getDelegationsUsingGET(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(coreDelegationApiRestClient._getDelegationsUsingGET(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(delegationResponseEntity);
 
 
@@ -258,7 +258,7 @@ class CoreConnectorImplTest {
         assertEquals(0, delegationList.size());
 
         verify(coreDelegationApiRestClient, times(1))
-                ._getDelegationsUsingGET(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getMode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
+                ._getDelegationsUsingGET(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
         verifyNoMoreInteractions(coreDelegationApiRestClient);
     }
 
@@ -273,7 +273,7 @@ class CoreConnectorImplTest {
         ResponseEntity<DelegationWithPaginationResponse> delegationResponseEntity = new ResponseEntity<>(delegationWithPaginationResponse, null, HttpStatus.OK);
         GetDelegationParameters parameters = dummyDelegationParameters();
 
-        when(coreDelegationApiRestClient._getDelegationsUsingGET1(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(coreDelegationApiRestClient._getDelegationsUsingGET1(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(delegationResponseEntity);
 
 
@@ -292,7 +292,7 @@ class CoreConnectorImplTest {
         assertEquals(delegationResponseList.get(0).getBrokerName(), response.getDelegations().get(0).getBrokerName());
 
         verify(coreDelegationApiRestClient, times(1))
-                ._getDelegationsUsingGET1(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getMode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
+                ._getDelegationsUsingGET1(parameters.getFrom(), parameters.getTo(), parameters.getProductId(), parameters.getSearch(), parameters.getTaxCode(), parameters.getOrder(), parameters.getPage(), parameters.getSize());
         verifyNoMoreInteractions(coreDelegationApiRestClient);
     }
 
@@ -519,7 +519,6 @@ class CoreConnectorImplTest {
                 .productId("setProductId")
                 .taxCode("taxCode")
                 .search("name")
-                .mode(GetDelegationsMode.FULL.name())
                 .order(Order.ASC.name())
                 .page(0)
                 .size(1000)

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
@@ -122,7 +122,6 @@ class DelegationServiceImplTest {
                 .productId("product-io")
                 .taxCode("taxCode")
                 .search("name")
-                .mode(GetDelegationsMode.FULL.name())
                 .order(Order.ASC.name())
                 .page(0)
                 .size(1000)

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationParameters;
-import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationsMode;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Order;
 import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomyList;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
@@ -219,10 +218,6 @@ public class InstitutionController {
                                                                    @RequestParam(name = "productId", required = false) String productId,
                                                                    @ApiParam("${swagger.dashboard.delegation.model.description}")
                                                                    @RequestParam(name = "search", required = false) String search,
-                                                                   @ApiParam("${swagger.dashboard.delegation.model.taxCode}")
-                                                                   @RequestParam(name = "taxCode", required = false) String taxCode,
-                                                                   @ApiParam("${swagger.dashboard.delegation.delegations.mode}")
-                                                                   @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                    @ApiParam("${swagger.dashboard.delegation.delegations.order}")
                                                                    @RequestParam(name = "order", required = false) Order order,
                                                                    @RequestParam(name = "page", required = false) Integer page,
@@ -234,8 +229,6 @@ public class InstitutionController {
                 .to(institutionId)
                 .productId(productId)
                 .search(search)
-                .taxCode(taxCode)
-                .mode(Objects.nonNull(mode) ? mode.name() : null)
                 .order(Objects.nonNull(order) ? order.name() : null)
                 .page(page)
                 .size(size)

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2Controller.java
@@ -7,7 +7,6 @@ import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationWithPagination;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationParameters;
-import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationsMode;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.Order;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionBase;
@@ -171,10 +170,6 @@ public class InstitutionV2Controller {
                                                                           @RequestParam(name = "productId", required = false) String productId,
                                                                           @ApiParam("${swagger.dashboard.delegation.model.description}")
                                                                           @RequestParam(name = "search", required = false) String search,
-                                                                          @ApiParam("${swagger.dashboard.delegation.model.taxCode}")
-                                                                          @RequestParam(name = "taxCode", required = false) String taxCode,
-                                                                          @ApiParam("${swagger.dashboard.delegation.delegations.mode}")
-                                                                          @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                           @ApiParam("${swagger.dashboard.delegation.delegations.order}")
                                                                           @RequestParam(name = "order", required = false) Order order,
                                                                           @RequestParam(name = "page", required = false) @Min(0) Integer page,
@@ -186,8 +181,6 @@ public class InstitutionV2Controller {
                 .to(institutionId)
                 .productId(productId)
                 .search(search)
-                .taxCode(taxCode)
-                .mode(Objects.nonNull(mode) ? mode.name() : null)
                 .order(Objects.nonNull(order) ? order.name() : null)
                 .page(page)
                 .size(size)

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionControllerTest.java
@@ -2,7 +2,10 @@ package it.pagopa.selfcare.dashboard.web.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import it.pagopa.selfcare.dashboard.connector.model.delegation.*;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationType;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationParameters;
+import it.pagopa.selfcare.dashboard.connector.model.delegation.Order;
 import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomy;
 import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomyList;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
@@ -311,7 +314,7 @@ class InstitutionControllerTest {
     }
 
     /**
-     * Method under test: {@link InstitutionController#getDelegationsUsingTo(String, String, String, String, GetDelegationsMode, Order, Integer, Integer)}
+     * Method under test: {@link InstitutionController#getDelegationsUsingTo(String, String, String, Order, Integer, Integer)}
      */
     @Test
     void getDelegationsUsingTo_shouldGetData() throws Exception {
@@ -402,9 +405,7 @@ class InstitutionControllerTest {
         return GetDelegationParameters.builder()
                 .to("to")
                 .productId("setProductId")
-                .taxCode("taxCode")
                 .search("name")
-                .mode(GetDelegationsMode.FULL.name())
                 .order(Order.ASC.name())
                 .page(0)
                 .size(1000)

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
@@ -326,7 +326,7 @@ class InstitutionV2ControllerTest {
         // Given
         DelegationWithInfo expectedDelegation = dummyDelegation();
         PageInfo exptectedPageInfo = new PageInfo(10, 0, 1, 1);
-        GetDelegationParameters delegationParameters = createDelegationParameters(null, "to", "prod-id", "taxCode", "search", GetDelegationsMode.FULL, Order.ASC, 0, 10);
+        GetDelegationParameters delegationParameters = createDelegationParameters(null, "to", "prod-id", "search", Order.ASC, 0, 10);
         DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(List.of(expectedDelegation), exptectedPageInfo);
 
         when(delegationServiceMock.getDelegationsV2(any())).thenReturn(expectedDelegationWithPagination);
@@ -384,15 +384,13 @@ class InstitutionV2ControllerTest {
     }
 
     private GetDelegationParameters createDelegationParameters(String from, String to, String productId,
-                                                               String search, String taxCode, GetDelegationsMode mode,
-                                                               Order order, Integer page, Integer size) {
+                                                               String search, Order order,
+                                                               Integer page, Integer size) {
         return GetDelegationParameters.builder()
                 .from(from)
                 .to(to)
                 .productId(productId)
                 .search(search)
-                .taxCode(taxCode)
-                .mode(mode.name())
                 .order(order.name())
                 .page(page)
                 .size(size)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- remove taxCode and mode filters from getDelegationsV2
- align core openapi
- align unit tests
- update swagger

<!--- Describe your changes in detail -->

#### Motivation and Context
Mode filter is no longer available because taxCode field is always returned.
TaxCode filter, in dashboard page "Enti gestiti", is managed by frontend.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running bff-dashboard locally and calling APIs getDelegationsUsingTo, getDelegationsUsingFrom and getDelegationsUsingToV2.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.