### PR TITLE
[SELC-4846] Feat: Refactor retrievedIds method

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
@@ -33,6 +33,8 @@ public interface UserApiConnector {
 
     Collection<UserInfo> getUsers(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId);
 
+    List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId);
+
     List<UserInstitution> retrieveFilteredUser(String userId, String institutionId, String productId);
 
     String createOrUpdateUserByFiscalCode(Institution institution, String productId, UserToCreate userDto, List<CreateUserDto.Role> role);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -186,7 +186,9 @@ public class UserConnectorImpl implements UserApiConnector {
                                 null,
                                 List.of(userInfoFilter.getProductId()),
                                 null,
-                                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(),
+                                Optional.ofNullable(userInfoFilter.getAllowedStates())
+                                        .map(relationshipStates -> relationshipStates.stream().map(Enum::name).toList())
+                                        .orElse(null),
                                 loggedUserId)
                         .getBody()).map(userInstitutionResponses -> userInstitutionResponses.stream()
                         .map(UserInstitutionResponse::getUserId).toList())

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -180,6 +180,20 @@ public class UserConnectorImpl implements UserApiConnector {
     }
 
     @Override
+    public List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId) {
+
+        return Optional.ofNullable(userInstitutionApiRestClient._institutionsInstitutionIdUserInstitutionsGet(institutionId,
+                                null,
+                                List.of(userInfoFilter.getProductId()),
+                                null,
+                                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(),
+                                loggedUserId)
+                        .getBody()).map(userInstitutionResponses -> userInstitutionResponses.stream()
+                        .map(UserInstitutionResponse::getUserId).toList())
+                .orElse(Collections.emptyList());
+    }
+
+    @Override
     @Retry(name = "retryTimeout")
     public List<UserInstitution> retrieveFilteredUser(String userId, String institutionId, String productId) {
         log.trace("retrieveFilteredUser start");

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImpl.java
@@ -85,11 +85,10 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
     private List<String> retrievedIds(String institutionId, UserInfo.UserInfoFilter userInfoFilter) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String loggedUserId = ((SelfCareUser) authentication.getPrincipal()).getId();
-        Collection<UserInfo> retrievedUsers = userApiConnector.getUsers(
+        List<String> retrievedUsers = userApiConnector.retrieveFilteredUserInstitution(
                 institutionId,
                 userInfoFilter, loggedUserId);
         return retrievedUsers.stream()
-                .map(UserInfo::getId)
                 .sorted()
                 .toList();
     }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImplTest.java
@@ -56,7 +56,7 @@ class UserGroupV2ServiceImplTest {
     @Test
     void createGroup() {
         Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
+        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("setId").build());
         SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         CreateUserGroup userGroup = mockInstance(new CreateUserGroup());
@@ -79,9 +79,8 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.createUserGroup(any()))
                 .thenReturn(groupIdMock);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+                .thenReturn(List.of(id1, id2, id3, id4));   //when
         String groupId = userV2GroupServiceImpl.createUserGroup(userGroup);
         //then
         assertEquals(groupIdMock, groupId);
@@ -89,7 +88,7 @@ class UserGroupV2ServiceImplTest {
                 .createUserGroup(any());
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("setId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -122,16 +121,15 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), any(), eq("loggedUserId")))
+                .thenReturn(List.of("setId", "setId", "setId", "setId"));   //when
         Executable executable = () -> userV2GroupServiceImpl.createUserGroup(userGroup);
         //then
         InvalidMemberListException e = assertThrows(InvalidMemberListException.class, executable);
         assertEquals("Some members in the list aren't allowed for this institution", e.getMessage());
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -229,24 +227,23 @@ class UserGroupV2ServiceImplTest {
         List<String> userIds = List.of(id1, id2, id3, id4);
         userGroup.setMembers(userIds);
 
-        UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "setId");
+        UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "loggedUserId");
         foundGroup.setId(groupId);
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        UserInfo userInfoMock1 = mockInstance(new UserInfo(), 1, "setId");
-        UserInfo userInfoMock2 = mockInstance(new UserInfo(), 2, "setId");
-        UserInfo userInfoMock3 = mockInstance(new UserInfo(), 3, "setId");
-        UserInfo userInfoMock4 = mockInstance(new UserInfo(), 4, "setId");
+        UserInfo userInfoMock1 = mockInstance(new UserInfo(), 1, "loggedUserId");
+        UserInfo userInfoMock2 = mockInstance(new UserInfo(), 2, "loggedUserId");
+        UserInfo userInfoMock3 = mockInstance(new UserInfo(), 3, "loggedUserId");
+        UserInfo userInfoMock4 = mockInstance(new UserInfo(), 4, "loggedUserId");
 
         userInfoMock1.setId(id1);
         userInfoMock2.setId(id2);
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+                .thenReturn(List.of(id1, id2, id3, id4)); //when
         Executable executable = () -> userV2GroupServiceImpl.updateUserGroup(groupId, userGroup);
         //then
         assertDoesNotThrow(executable);
@@ -255,7 +252,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -297,9 +294,8 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), any(), eq("loggedUserId")))
+                .thenReturn(List.of("setId", "setId", "setId", "setId"));   //when
         Executable executable = () -> userV2GroupServiceImpl.updateUserGroup(groupId, userGroup);
         //then
         InvalidMemberListException e = assertThrows(InvalidMemberListException.class, executable);
@@ -307,7 +303,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -346,8 +342,10 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void addMemberToUserGroup() {
+        UUID userId = randomUUID();
+
         Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
+        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder(userId.toString()).build());
         SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
@@ -355,7 +353,6 @@ class UserGroupV2ServiceImplTest {
         String productId = "productId";
         UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "setId", "setInstitutionId");
         foundGroup.setId(groupId);
-        UUID userId = randomUUID();
         String id2 = randomUUID().toString();
         String id3 = randomUUID().toString();
         String id4 = randomUUID().toString();
@@ -369,8 +366,6 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
-
         foundGroup.setMembers(List.of(userInfoMock2, userInfoMock3, userInfoMock4));
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
@@ -380,9 +375,8 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(members);
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId), any(), eq(userId.toString())))
+                .thenReturn(List.of(userId.toString(), "setId", "setId", "setId"));  //when
         Executable executable = () -> userV2GroupServiceImpl.addMemberToUserGroup(groupId, userId);
         //then
         assertDoesNotThrow(executable);
@@ -392,7 +386,7 @@ class UserGroupV2ServiceImplTest {
                 .getUserGroupById(groupId);
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq(userId.toString()));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -429,8 +423,6 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
-
         foundGroup.setMembers(List.of(userInfoMock2, userInfoMock3, userInfoMock4));
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
@@ -440,9 +432,9 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(members);
-        //when
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId),  any(), eq("loggedUserId")))
+                .thenReturn(List.of("setId", "setId", "setId", "setId"));
+
         Executable executable = () -> userV2GroupServiceImpl.addMemberToUserGroup(groupId, userId);
         //then
         InvalidMemberListException e = assertThrows(InvalidMemberListException.class, executable);
@@ -451,7 +443,7 @@ class UserGroupV2ServiceImplTest {
                 .getUserGroupById(groupId);
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -551,7 +543,7 @@ class UserGroupV2ServiceImplTest {
     @Test
     void getUserGroupById() {
         Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
+        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("setId").build());
         SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
@@ -574,10 +566,8 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
-
-        foundGroup.setMembers(members);
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+                .thenReturn(List.of("setId", "setId", "setId", "setId")); foundGroup.setMembers(members);
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
         foundGroup.setInstitutionId(institutionId);
@@ -625,12 +615,12 @@ class UserGroupV2ServiceImplTest {
         assertEquals(modifiedByMock.getId(), groupInfo.getModifiedBy().getId());
         verify(userGroupConnector, times(1))
                 .getUserGroupById(anyString());
-        verify(userApiConnector, times(6))
+        verify(userApiConnector, times(2))
                 .getUserById(any(), any(),anyList());
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("setId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -666,8 +656,8 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.getUsers(anyString(), any(), any()))
-                .thenReturn(List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4));
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+                .thenReturn(List.of("setId", "setId", "setId", "setId"));
 
         foundGroup.setMembers(members);
         foundGroup.setCreatedAt(Instant.now());
@@ -737,8 +727,8 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.getUsers(any(), any(), any()))
-                .thenReturn(List.of(userInfoMock4));
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+                .thenReturn(List.of(id1, id2, id3, id4));
         when(userApiConnector.getUserById(anyString(), any(), any()))
                 .thenAnswer(invocation -> {
                     User userMock = new User();
@@ -779,7 +769,7 @@ class UserGroupV2ServiceImplTest {
         assertEquals(foundGroup.getStatus(), groupInfo.getStatus());
         assertEquals(foundGroup.getDescription(), groupInfo.getDescription());
         assertEquals(foundGroup.getName(), groupInfo.getName());
-        assertEquals(1, groupInfo.getMembers().size());
+        assertEquals(4, groupInfo.getMembers().size());
         assertEquals(foundGroup.getCreatedAt(), groupInfo.getCreatedAt());
         assertEquals(createdByMock.getId(), groupInfo.getCreatedBy().getId());
         assertEquals(foundGroup.getModifiedAt(), groupInfo.getModifiedAt());
@@ -789,7 +779,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .getUsers(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Refactor retrievedIds method to invoke user api to retrieve UserInstitutions instead of UserData containing data from PDV
<!--- Describe your changes in detail -->

#### Motivation and Context
For userGroup we need only id of user, so we can use user-be API to  retrieve UserInstitutions instead of UserData containing data from PDV
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.