### PR TITLE
[SELC-4846] Fix: refactor retrieveFilteredUserInstitution to remove loggedUserId as filter parameter

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/UserApiConnector.java
@@ -33,7 +33,7 @@ public interface UserApiConnector {
 
     Collection<UserInfo> getUsers(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId);
 
-    List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId);
+    List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter);
 
     List<UserInstitution> retrieveFilteredUser(String userId, String institutionId, String productId);
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -180,7 +180,7 @@ public class UserConnectorImpl implements UserApiConnector {
     }
 
     @Override
-    public List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter, String loggedUserId) {
+    public List<String> retrieveFilteredUserInstitution(String institutionId, UserInfo.UserInfoFilter userInfoFilter) {
 
         return Optional.ofNullable(userInstitutionApiRestClient._institutionsInstitutionIdUserInstitutionsGet(institutionId,
                                 null,
@@ -189,7 +189,7 @@ public class UserConnectorImpl implements UserApiConnector {
                                 Optional.ofNullable(userInfoFilter.getAllowedStates())
                                         .map(relationshipStates -> relationshipStates.stream().map(Enum::name).toList())
                                         .orElse(null),
-                                loggedUserId)
+                                null)
                         .getBody()).map(userInstitutionResponses -> userInstitutionResponses.stream()
                         .map(UserInstitutionResponse::getUserId).toList())
                 .orElse(Collections.emptyList());

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
@@ -426,14 +426,13 @@ class UserConnectorImplTest {
         UserInfo.UserInfoFilter userInfoFilter = new UserInfo.UserInfoFilter();
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
         userInfoFilter.setProductId("productId");
-        String loggedUserId = "loggedUserId";
         List<UserInstitutionResponse> userInstitutionResponses = List.of(new UserInstitutionResponse(), new UserInstitutionResponse());
         when(userInstitutionApiRestClient._institutionsInstitutionIdUserInstitutionsGet(institutionId, null, List.of(userInfoFilter.getProductId()), null,
-                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(), loggedUserId))
+                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(), null))
                 .thenReturn(ResponseEntity.ok(userInstitutionResponses));
 
         // When
-        List<String> result = userConnector.retrieveFilteredUserInstitution(institutionId, userInfoFilter, loggedUserId);
+        List<String> result = userConnector.retrieveFilteredUserInstitution(institutionId, userInfoFilter);
 
         // Then
         assertEquals(userInstitutionResponses.size(), result.size());
@@ -446,13 +445,12 @@ class UserConnectorImplTest {
         UserInfo.UserInfoFilter userInfoFilter = new UserInfo.UserInfoFilter();
         userInfoFilter.setProductId("productId");
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
-        String loggedUserId = "loggedUserId";
         when(userInstitutionApiRestClient._institutionsInstitutionIdUserInstitutionsGet(institutionId, null, List.of(userInfoFilter.getProductId()), null,
-                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(), loggedUserId))
+                userInfoFilter.getAllowedStates().stream().map(Enum::name).toList(), null))
                 .thenReturn(ResponseEntity.ok(List.of()));
 
         // When
-        List<String> result = userConnector.retrieveFilteredUserInstitution(institutionId, userInfoFilter, loggedUserId);
+        List<String> result = userConnector.retrieveFilteredUserInstitution(institutionId, userInfoFilter);
 
         // Then
         assertEquals(0, result.size());

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImpl.java
@@ -51,7 +51,7 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
         userInfoFilter.setProductId(group.getProductId());
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
 
-        List<String> retrievedId = retrievedIds(group.getInstitutionId(), userInfoFilter);
+        List<String> retrievedId = retrieveIds(group.getInstitutionId(), userInfoFilter);
 
         if (group.getMembers().stream()
                 .filter(uuid -> Collections.binarySearch(retrievedId, uuid) >= 0)
@@ -82,12 +82,10 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
         log.trace("activate end");
     }
 
-    private List<String> retrievedIds(String institutionId, UserInfo.UserInfoFilter userInfoFilter) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String loggedUserId = ((SelfCareUser) authentication.getPrincipal()).getId();
+    private List<String> retrieveIds(String institutionId, UserInfo.UserInfoFilter userInfoFilter) {
         List<String> retrievedUsers = userApiConnector.retrieveFilteredUserInstitution(
                 institutionId,
-                userInfoFilter, loggedUserId);
+                userInfoFilter);
         return retrievedUsers.stream()
                 .sorted()
                 .toList();
@@ -112,7 +110,7 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
         userInfoFilter.setProductId(userGroupInfo.getProductId());
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
 
-        List<String> retrievedId = retrievedIds(userGroupInfo.getInstitutionId(), userInfoFilter);
+        List<String> retrievedId = retrieveIds(userGroupInfo.getInstitutionId(), userInfoFilter);
 
         if (group.getMembers().stream()
                 .filter(uuid -> Collections.binarySearch(retrievedId, uuid) >= 0)
@@ -133,7 +131,7 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
         UserInfo.UserInfoFilter userInfoFilter = new UserInfo.UserInfoFilter();
         userInfoFilter.setProductId(retrievedGroup.getProductId());
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
-        List<String> retrievedIds = retrievedIds(retrievedGroup.getInstitutionId(), userInfoFilter);
+        List<String> retrievedIds = retrieveIds(retrievedGroup.getInstitutionId(), userInfoFilter);
         if (!retrievedIds.contains(userId.toString())) {
             throw new InvalidMemberListException("This user is not allowed for this group");
         }
@@ -166,7 +164,7 @@ public class UserGroupV2ServiceImpl implements UserGroupV2Service{
         UserInfo.UserInfoFilter userInfoFilter = new UserInfo.UserInfoFilter();
         userInfoFilter.setProductId(userGroupInfo.getProductId());
         userInfoFilter.setAllowedStates(List.of(ACTIVE, SUSPENDED));
-        List<UserInfo> userInfos = retrievedIds(userGroupInfo.getInstitutionId(), userInfoFilter).stream()
+        List<UserInfo> userInfos = retrieveIds(userGroupInfo.getInstitutionId(), userInfoFilter).stream()
                 .map(id -> {
                     UserInfo userInfo = new UserInfo();
                     userInfo.setId(id);

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserGroupV2ServiceImplTest.java
@@ -55,9 +55,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void createGroup() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("setId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         CreateUserGroup userGroup = mockInstance(new CreateUserGroup());
         String id1 = randomUUID().toString();
@@ -79,7 +76,7 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.createUserGroup(any()))
                 .thenReturn(groupIdMock);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any()))
                 .thenReturn(List.of(id1, id2, id3, id4));   //when
         String groupId = userV2GroupServiceImpl.createUserGroup(userGroup);
         //then
@@ -88,7 +85,7 @@ class UserGroupV2ServiceImplTest {
                 .createUserGroup(any());
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("setId"));
+                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -100,9 +97,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void createGroup_invalidList() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         CreateUserGroup userGroup = mockInstance(new CreateUserGroup());
         String id1 = randomUUID().toString();
@@ -121,7 +115,7 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), any(), eq("loggedUserId")))
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), any()))
                 .thenReturn(List.of("setId", "setId", "setId", "setId"));   //when
         Executable executable = () -> userV2GroupServiceImpl.createUserGroup(userGroup);
         //then
@@ -129,7 +123,7 @@ class UserGroupV2ServiceImplTest {
         assertEquals("Some members in the list aren't allowed for this institution", e.getMessage());
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(userGroup.getInstitutionId()), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -214,9 +208,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void updateUserGroup() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         UpdateUserGroup userGroup = mockInstance(new UpdateUserGroup());
@@ -227,22 +218,22 @@ class UserGroupV2ServiceImplTest {
         List<String> userIds = List.of(id1, id2, id3, id4);
         userGroup.setMembers(userIds);
 
-        UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "loggedUserId");
+        UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "setId");
         foundGroup.setId(groupId);
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        UserInfo userInfoMock1 = mockInstance(new UserInfo(), 1, "loggedUserId");
-        UserInfo userInfoMock2 = mockInstance(new UserInfo(), 2, "loggedUserId");
-        UserInfo userInfoMock3 = mockInstance(new UserInfo(), 3, "loggedUserId");
-        UserInfo userInfoMock4 = mockInstance(new UserInfo(), 4, "loggedUserId");
+        UserInfo userInfoMock1 = mockInstance(new UserInfo(), 1, "setId");
+        UserInfo userInfoMock2 = mockInstance(new UserInfo(), 2, "setId");
+        UserInfo userInfoMock3 = mockInstance(new UserInfo(), 3, "setId");
+        UserInfo userInfoMock4 = mockInstance(new UserInfo(), 4, "setId");
 
         userInfoMock1.setId(id1);
         userInfoMock2.setId(id2);
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any()))
                 .thenReturn(List.of(id1, id2, id3, id4)); //when
         Executable executable = () -> userV2GroupServiceImpl.updateUserGroup(groupId, userGroup);
         //then
@@ -252,7 +243,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -266,9 +257,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void updateUserGroup_invalidMembersList() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         UpdateUserGroup userGroup = mockInstance(new UpdateUserGroup());
@@ -294,7 +282,7 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), any(), eq("loggedUserId")))
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), any()))
                 .thenReturn(List.of("setId", "setId", "setId", "setId"));   //when
         Executable executable = () -> userV2GroupServiceImpl.updateUserGroup(groupId, userGroup);
         //then
@@ -303,7 +291,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(foundGroup.getInstitutionId()), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -342,17 +330,13 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void addMemberToUserGroup() {
-        UUID userId = randomUUID();
-
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder(userId.toString()).build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         String institutionId = "institutionId";
         String productId = "productId";
         UserGroupInfo foundGroup = mockInstance(new UserGroupInfo(), "setId", "setInstitutionId");
         foundGroup.setId(groupId);
+        UUID userId = randomUUID();
         String id2 = randomUUID().toString();
         String id3 = randomUUID().toString();
         String id4 = randomUUID().toString();
@@ -366,6 +350,8 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
+        List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
+
         foundGroup.setMembers(List.of(userInfoMock2, userInfoMock3, userInfoMock4));
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
@@ -375,7 +361,7 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId), any(), eq(userId.toString())))
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId), any()))
                 .thenReturn(List.of(userId.toString(), "setId", "setId", "setId"));  //when
         Executable executable = () -> userV2GroupServiceImpl.addMemberToUserGroup(groupId, userId);
         //then
@@ -386,7 +372,7 @@ class UserGroupV2ServiceImplTest {
                 .getUserGroupById(groupId);
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq(userId.toString()));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -399,9 +385,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void addMemberToUserGroup_invalidMember() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         String institutionId = "institutionId";
@@ -423,6 +406,8 @@ class UserGroupV2ServiceImplTest {
         userInfoMock3.setId(id3);
         userInfoMock4.setId(id4);
 
+        List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
+
         foundGroup.setMembers(List.of(userInfoMock2, userInfoMock3, userInfoMock4));
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
@@ -432,7 +417,7 @@ class UserGroupV2ServiceImplTest {
         when(userGroupConnector.getUserGroupById(anyString()))
                 .thenReturn(foundGroup);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId),  any(), eq("loggedUserId")))
+        when(userApiConnector.retrieveFilteredUserInstitution(eq(institutionId),  any()))
                 .thenReturn(List.of("setId", "setId", "setId", "setId"));
 
         Executable executable = () -> userV2GroupServiceImpl.addMemberToUserGroup(groupId, userId);
@@ -443,7 +428,7 @@ class UserGroupV2ServiceImplTest {
                 .getUserGroupById(groupId);
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -542,9 +527,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void getUserGroupById() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("setId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         String institutionId = "institutionId";
@@ -566,8 +548,8 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
-                .thenReturn(List.of("setId", "setId", "setId", "setId")); foundGroup.setMembers(members);
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any()))
+                .thenReturn(List.of(id1, id2, id3, id4)); foundGroup.setMembers(members);
         foundGroup.setCreatedAt(Instant.now());
         foundGroup.setModifiedAt(Instant.now());
         foundGroup.setInstitutionId(institutionId);
@@ -615,12 +597,12 @@ class UserGroupV2ServiceImplTest {
         assertEquals(modifiedByMock.getId(), groupInfo.getModifiedBy().getId());
         verify(userGroupConnector, times(1))
                 .getUserGroupById(anyString());
-        verify(userApiConnector, times(2))
+        verify(userApiConnector, times(6))
                 .getUserById(any(), any(),anyList());
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("setId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());
@@ -632,9 +614,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void getUserGroupById_nullModifiedBy() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         String institutionId = "institutionId";
@@ -656,7 +635,7 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any()))
                 .thenReturn(List.of("setId", "setId", "setId", "setId"));
 
         foundGroup.setMembers(members);
@@ -703,9 +682,6 @@ class UserGroupV2ServiceImplTest {
 
     @Test
     void getUserGroupById_noRelationshipMember() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("loggedUserId").build());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         //given
         String groupId = "groupId";
         String institutionId = "institutionId";
@@ -727,8 +703,8 @@ class UserGroupV2ServiceImplTest {
 
         List<UserInfo> members = List.of(userInfoMock1, userInfoMock2, userInfoMock3, userInfoMock4);
 
-        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any(), any()))
-                .thenReturn(List.of(id1, id2, id3, id4));
+        when(userApiConnector.retrieveFilteredUserInstitution(anyString(), any()))
+                .thenReturn(List.of(id4));
         when(userApiConnector.getUserById(anyString(), any(), any()))
                 .thenAnswer(invocation -> {
                     User userMock = new User();
@@ -769,7 +745,7 @@ class UserGroupV2ServiceImplTest {
         assertEquals(foundGroup.getStatus(), groupInfo.getStatus());
         assertEquals(foundGroup.getDescription(), groupInfo.getDescription());
         assertEquals(foundGroup.getName(), groupInfo.getName());
-        assertEquals(4, groupInfo.getMembers().size());
+        assertEquals(1, groupInfo.getMembers().size());
         assertEquals(foundGroup.getCreatedAt(), groupInfo.getCreatedAt());
         assertEquals(createdByMock.getId(), groupInfo.getCreatedBy().getId());
         assertEquals(foundGroup.getModifiedAt(), groupInfo.getModifiedAt());
@@ -779,7 +755,7 @@ class UserGroupV2ServiceImplTest {
 
         ArgumentCaptor<UserInfo.UserInfoFilter> filterCaptor = ArgumentCaptor.forClass(UserInfo.UserInfoFilter.class);
         verify(userApiConnector, times(1))
-                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture(), eq("loggedUserId"));
+                .retrieveFilteredUserInstitution(eq(institutionId), filterCaptor.capture());
         UserInfo.UserInfoFilter capturedFilter = filterCaptor.getValue();
         assertNull(capturedFilter.getUserId());
         assertNull(capturedFilter.getProductRoles());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- refactor retrieveFilteredUserInstitution to remove loggedUserId as filter parameter
<!--- Describe your changes in detail -->

#### Motivation and Context
We don't need to filter for userId on userInstitution collection
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.