### PR TITLE
[SELC-4950] Feat: Added typ and sub in Jwt claims in ExchangeTokenServiceV2

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2.java
@@ -54,7 +54,7 @@ public class ExchangeTokenServiceV2 {
 
     private static final String PRIVATE_KEY_HEADER_TEMPLATE = "-----BEGIN %s-----";
     private static final String PRIVATE_KEY_FOOTER_TEMPLATE = "-----END %s-----";
-
+    private static final String ID = "ID";
     private final String billingUrl;
     private final String billingAudience;
     private final PrivateKey jwtSigningKey;
@@ -204,6 +204,8 @@ public class ExchangeTokenServiceV2 {
         claims.setDesiredExpiration(claims.getExpiration());
         claims.setIssuedAt(new Date());
         claims.setExpiration(Date.from(claims.getIssuedAt().toInstant().plus(duration)));
+        claims.setSubject(UUID.fromString(userId).toString());
+        claims.setType(ID);
 
         return claims;
     }
@@ -336,6 +338,7 @@ public class ExchangeTokenServiceV2 {
         public static final String DESIRED_EXPIRATION = "desired_exp";
         public static final String INSTITUTION = "organization";
         public static final String EMAIL = "email";
+        public static final String TYPE = "typ";
 
         public TokenExchangeClaims(Map<String, Object> map) {
             super(map);
@@ -353,6 +356,11 @@ public class ExchangeTokenServiceV2 {
 
         public Claims setEmail(String email) {
             setValue(EMAIL, email);
+            return this;
+        }
+
+        public Claims setType(String type) {
+            setValue(TYPE, type);
             return this;
         }
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
@@ -283,10 +283,6 @@ class ExchangeTokenServiceV2Test {
         // given
         String institutionId = "institutionId";
         String productId = "productId";
-        String jti = "id";
-        String sub = "subject";
-        Date iat = Date.from(Instant.now().minusSeconds(1));
-        Date exp = Date.from(iat.toInstant().plusSeconds(5));
         File file = ResourceUtils.getFile("classpath:certs/PKCS8key.pem");
         String jwtSigningKey = Files.readString(file.toPath(), Charset.defaultCharset());
         ExchangeTokenProperties properties = new ExchangeTokenProperties();
@@ -591,7 +587,6 @@ class ExchangeTokenServiceV2Test {
         final ExchangedToken exchangedToken = ExchangeTokenServiceV2.exchange(institutionId, productId, Optional.empty());
         // then
         assertEquals(product.getUrlBO(), exchangedToken.getBackOfficeUrl());
-        assertNotNull(exchangedToken.getIdentityToken());
         Jws<Claims> claimsJws = Jwts.parser()
                 .setSigningKey(loadPublicKey())
                 .parseClaimsJws(exchangedToken.getIdentityToken());
@@ -604,9 +599,6 @@ class ExchangeTokenServiceV2Test {
         assertEquals(userId.toString(), exchangedClaims.getSubject());
         assertEquals(issuer, exchangedClaims.getIssuer());
         assertEquals(realm, exchangedClaims.getAudience());
-        // https://github.com/jwtk/jjwt/issues/122:
-        // The JWT RFC *mandates* NumericDate values are represented as seconds.
-        // Because java.util.Date requires milliseconds, we need to multiply by 1000:
         assertEquals(exp.toInstant().getEpochSecond(), exchangedClaims.getDesiredExpiration().toInstant().getEpochSecond());
         assertTrue(exchangedClaims.getIssuedAt().after(iat));
         assertTrue(exchangedClaims.getExpiration().after(exp));

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/security/ExchangeTokenServiceV2Test.java
@@ -444,7 +444,7 @@ class ExchangeTokenServiceV2Test {
         TestTokenExchangeClaims exchangedClaims = new TestTokenExchangeClaims(claimsJws.getBody());
         assertNotEquals(jti, exchangedClaims.getId());
         assertNotEquals(0, exp.compareTo(exchangedClaims.getExpiration()));
-        assertEquals(sub, exchangedClaims.getSubject());
+        assertEquals(userId.toString(), exchangedClaims.getSubject());
         assertEquals(issuer, exchangedClaims.getIssuer());
         assertEquals(realm, exchangedClaims.getAudience());
         // https://github.com/jwtk/jjwt/issues/122:
@@ -601,7 +601,7 @@ class ExchangeTokenServiceV2Test {
         TestTokenExchangeClaims exchangedClaims = new TestTokenExchangeClaims(claimsJws.getBody());
         assertNotEquals(jti, exchangedClaims.getId());
         assertNotEquals(0, exp.compareTo(exchangedClaims.getExpiration()));
-        assertEquals(sub, exchangedClaims.getSubject());
+        assertEquals(userId.toString(), exchangedClaims.getSubject());
         assertEquals(issuer, exchangedClaims.getIssuer());
         assertEquals(realm, exchangedClaims.getAudience());
         // https://github.com/jwtk/jjwt/issues/122:
@@ -857,7 +857,7 @@ class ExchangeTokenServiceV2Test {
         TestTokenExchangeClaims exchangedClaims = new TestTokenExchangeClaims(claimsJws.getBody());
         assertNotEquals(jti, exchangedClaims.getId());
         assertNotEquals(0, exp.compareTo(exchangedClaims.getExpiration()));
-        assertEquals(sub, exchangedClaims.getSubject());
+        assertEquals(userId.toString(), exchangedClaims.getSubject());
         assertEquals(issuer, exchangedClaims.getIssuer());
         // https://github.com/jwtk/jjwt/issues/122:
         // The JWT RFC *mandates* NumericDate values are represented as seconds.
@@ -888,7 +888,6 @@ class ExchangeTokenServiceV2Test {
     void billingExchange_ok(PrivateKey privateKey) throws Exception {
         // given
         String jti = "id";
-        String sub = "subject";
         Date iat = Date.from(Instant.now().minusSeconds(1));
         Date exp = Date.from(iat.toInstant().plusSeconds(5));
         String institutionId = "institutionId";
@@ -904,7 +903,6 @@ class ExchangeTokenServiceV2Test {
         when(jwtServiceMock.getClaims(any()))
                 .thenReturn(Jwts.claims()
                         .setId(jti)
-                        .setSubject(sub)
                         .setIssuedAt(iat)
                         .setExpiration(exp));
         InstitutionService institutionServiceMock = mock(InstitutionService.class);
@@ -982,7 +980,7 @@ class ExchangeTokenServiceV2Test {
         TestTokenExchangeClaims exchangedClaims = new TestTokenExchangeClaims(claimsJws.getBody());
         assertNotEquals(jti, exchangedClaims.getId());
         assertNotEquals(0, exp.compareTo(exchangedClaims.getExpiration()));
-        assertEquals(sub, exchangedClaims.getSubject());
+        assertEquals(userId.toString(), exchangedClaims.getSubject());
         assertEquals(issuer, exchangedClaims.getIssuer());
         // https://github.com/jwtk/jjwt/issues/122:
         // The JWT RFC *mandates* NumericDate values are represented as seconds.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added typ and sub in Jwt claims in ExchangeTokenServiceV2
<!--- Describe your changes in detail -->

#### Motivation and Context
To use keycloak for tokenExchange we need to add these 2 claims in token payload.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.