### PR TITLE
[SELC-5224] feat: add product pagoPa condition in createDelegation

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/MsCoreConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/MsCoreConnector.java
@@ -16,6 +16,8 @@ public interface MsCoreConnector {
 
     Institution getInstitution(String institutionId);
 
+    List<Institution> getInstitutionsFromTaxCode(String taxCode, String subunitCode, String origin, String originId);
+
     Institution updateInstitutionDescription(String institutionId, UpdateInstitutionResource updatePnPGInstitutionResource);
 
     DelegationId createDelegation(DelegationRequest delegation);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImpl.java
@@ -51,6 +51,8 @@ class CoreConnectorImpl implements MsCoreConnector {
     private final DelegationRestClientMapper delegationMapper;
 
     static final String REQUIRED_INSTITUTION_ID_MESSAGE = "An Institution id is required";
+    static final String REQUIRED_TAX_CODE_MESSAGE = "A taxCode is required";
+    static final String NO_INSTITUTION_FOUND = "No institution found with given taxCode";
     static final String REQUIRED_PRODUCT_ID_MESSAGE = "A Product id is required";
     static final String REQUIRED_INSTITUTION_TYPE_MESSAGE = "An Institution type is required";
     static final String REQUIRED_UPDATE_RESOURCE_MESSAGE = "An Institution description is required";
@@ -78,6 +80,19 @@ class CoreConnectorImpl implements MsCoreConnector {
         log.debug("updateInstitutionDescription result = {}", institution);
         log.trace("updateInstitutionDescription end");
         return institutionMapper.toInstitution(institution);
+    }
+
+    @Override
+    @Retry(name = "retryTimeout")
+    public List<Institution> getInstitutionsFromTaxCode(String taxCode, String subunitCode, String origin, String originId) {
+        log.trace("getInstitution start");
+        log.debug("getInstitution institutionId = {}", taxCode);
+        Assert.hasText(taxCode, REQUIRED_TAX_CODE_MESSAGE);
+        InstitutionsResponse institutions = coreInstitutionApiRestClient._getInstitutionsUsingGET(taxCode, subunitCode, origin, originId).getBody();
+        log.debug("getInstitution result = {}", institutions);
+        log.trace("getInstitution end");
+        Assert.notNull(institutions, NO_INSTITUTION_FOUND);
+        return institutions.getInstitutions().stream().map(institutionMapper::toInstitution).toList();
     }
 
     @Override

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/CoreConnectorImplTest.java
@@ -9,7 +9,10 @@ import it.pagopa.selfcare.dashboard.connector.model.delegation.Delegation;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationId;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.DelegationWithPagination;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.GetDelegationParameters;
-import it.pagopa.selfcare.dashboard.connector.model.institution.*;
+import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomy;
+import it.pagopa.selfcare.dashboard.connector.model.institution.GeographicTaxonomyList;
+import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
+import it.pagopa.selfcare.dashboard.connector.model.institution.UpdateInstitutionResource;
 import it.pagopa.selfcare.dashboard.connector.model.product.PartyProduct;
 import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.client.CoreDelegationApiRestClient;
@@ -132,6 +135,29 @@ class CoreConnectorImplTest extends BaseConnectorTest{
         assertEquals(institution, institutionMapperSpy.toInstitution(institutionMock));
         verify(coreInstitutionApiRestClient, times(1))
                 ._retrieveInstitutionByIdUsingGET(institutionId);
+    }
+
+    @Test
+    void getInstitutionsFromTaxCode() throws IOException {
+        // given
+        String institutionId = "institutionId";
+        ClassPathResource resource = new ClassPathResource("stubs/InstitutionResponse.json");
+        byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
+        InstitutionResponse institutionMock = objectMapper.readValue(resourceStream, new TypeReference<>() {
+        });
+
+        InstitutionsResponse institutionsResponse = new InstitutionsResponse();
+        institutionsResponse.setInstitutions(List.of(institutionMock));
+
+        when(coreInstitutionApiRestClient._getInstitutionsUsingGET(institutionMock.getTaxCode(), null, null, null))
+                .thenReturn(ResponseEntity.of(Optional.of(institutionsResponse)));
+        // when
+        List<Institution> institutions = msCoreConnector.getInstitutionsFromTaxCode(institutionMock.getTaxCode(), null, null, null);
+        // then
+
+        assertEquals(institutions.get(0), institutionMapperSpy.toInstitution(institutionMock));
+        verify(coreInstitutionApiRestClient, times(1))
+                ._getInstitutionsUsingGET(institutionMock.getTaxCode(), null, null, null);
     }
 
     @Test

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
@@ -1,18 +1,24 @@
 package it.pagopa.selfcare.dashboard.core;
 
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
+import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.*;
+import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static it.pagopa.selfcare.onboarding.common.ProductId.PROD_PAGOPA;
+
 @Slf4j
 @Service
 class DelegationServiceImpl implements DelegationService {
 
+    private static final String INSTITUTION_TAX_CODE_NOT_FOUND = "Cannot find Institution using taxCode %s";
     private final MsCoreConnector msCoreConnector;
 
 
@@ -25,10 +31,31 @@ class DelegationServiceImpl implements DelegationService {
     public DelegationId createDelegation(DelegationRequest delegation) {
         log.trace("createDelegation start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "createDelegation request = {}", delegation);
+
+        /*
+            In case of prod-pagopa product, in the attribute "to" of the delegation object a taxCode is inserted.
+            So we have to retrieve the institutionId from the taxCode and set it in the "to" attribute.
+         */
+        if(PROD_PAGOPA.getValue().equals(delegation.getProductId())) {
+            setToInstitutionId(delegation);
+        }
+
         DelegationId result = msCoreConnector.createDelegation(delegation);
         log.debug("createDelegation result = {}", result);
         log.trace("createDelegation end");
         return result;
+    }
+
+    private void setToInstitutionId(DelegationRequest delegation) {
+        List<Institution> institutions = msCoreConnector.getInstitutionsFromTaxCode(delegation.getTo(), null, null, null);
+        Institution partner = institutions.stream()
+                .filter(institution -> institution.getInstitutionType() == InstitutionType.PT)
+                .findFirst()
+                .orElse(institutions.stream().findFirst()
+                        .orElseThrow(() -> new ResourceNotFoundException(
+                                String.format(INSTITUTION_TAX_CODE_NOT_FOUND, delegation.getTo()))
+                        ));
+        delegation.setTo(partner.getId());
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.core;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
+import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.*;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Institution;
 import org.junit.jupiter.api.Assertions;
@@ -18,6 +19,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,6 +82,14 @@ class DelegationServiceImplTest extends BaseServiceTest {
                 .getInstitutionsFromTaxCode(delegationTaxCode.getTo(), null, null, null);
         Mockito.verify(msCoreConnector, Mockito.times(1))
                 .createDelegation(delegation);
+    }
+
+    @Test
+    void testCreateDelegationWithResourceNotFoundException() {
+        DelegationRequest delegationPagoPa = new DelegationRequest();
+        delegationPagoPa.setProductId("prod-pagopa");
+        when(msCoreConnector.getInstitutionsFromTaxCode(any(), any(), any(), any())).thenReturn(List.of());
+        assertThrows(ResourceNotFoundException.class, () -> delegationServiceImpl.createDelegation(delegationPagoPa));
     }
 
     @Test

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImplTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
+import static it.pagopa.selfcare.onboarding.common.ProductId.PROD_PAGOPA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -87,7 +88,7 @@ class DelegationServiceImplTest extends BaseServiceTest {
     @Test
     void testCreateDelegationWithResourceNotFoundException() {
         DelegationRequest delegationPagoPa = new DelegationRequest();
-        delegationPagoPa.setProductId("prod-pagopa");
+        delegationPagoPa.setProductId(PROD_PAGOPA.getValue());
         when(msCoreConnector.getInstitutionsFromTaxCode(any(), any(), any(), any())).thenReturn(List.of());
         assertThrows(ResourceNotFoundException.class, () -> delegationServiceImpl.createDelegation(delegationPagoPa));
     }

--- a/core/src/test/resources/expectations/DelegationRequestPagoPa.json
+++ b/core/src/test/resources/expectations/DelegationRequestPagoPa.json
@@ -1,0 +1,9 @@
+{
+  "id": "id",
+  "from": "john.doe@example.com",
+  "to": "jane.smith@example.com",
+  "productId": "prod-pagopa",
+  "institutionFromName": "Institution A",
+  "institutionToName": "Institution B",
+  "type": "AOO"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add product pagoPa condition in createDelegation
- add unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This change was required to move product pagoPa logic from BE to BFF.
With this modification createDelegation API on ms-core is semplied and reusable.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested locally by running both ms-core and bff-dashboard locally and calling createDelegation API. on bff-dashboard.
It was tested with both product prod-pagopa and prod-io.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.