### PR TITLE
[SELC-5617] feat: Replace commons InstitutionType with onboarding-sdk InstitutionType

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -764,47 +764,6 @@
         "summary" : "getInstitutions",
         "description" : "Service to get all the institutions related to logged user",
         "operationId" : "v2RetrieveUserInstitutions",
-        "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        } ],
         "responses" : {
           "200" : {
             "description" : "OK",
@@ -1318,38 +1277,6 @@
         "description" : "Service to get the users with the given user id related to a specific institution",
         "operationId" : "v2RetrieveInstitutionUser",
         "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
           "name" : "institutionId",
           "in" : "path",
           "description" : "Institution's unique internal identifier",
@@ -1357,14 +1284,6 @@
           "style" : "simple",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
           }
         }, {
           "name" : "userId",
@@ -1701,47 +1620,6 @@
         "summary" : "sendSupportRequest",
         "description" : "Service to retrieve Support contact's form",
         "operationId" : "sendSupportRequestUsingPOST",
-        "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2674,38 +2552,6 @@
         "description" : "Service to get all the users related to a specific institution",
         "operationId" : "v2GetUsersUsingGET",
         "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
           "name" : "institutionId",
           "in" : "path",
           "description" : "Institution's unique internal identifier",
@@ -2713,14 +2559,6 @@
           "style" : "simple",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
           }
         }, {
           "name" : "productId",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1774,38 +1774,6 @@
         "description" : "Service to create a 'Billing Token' based on a Self Care session token",
         "operationId" : "billingTokenUsingGET",
         "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
           "name" : "institutionId",
           "in" : "query",
           "description" : "Institution's unique internal identifier",
@@ -1813,22 +1781,6 @@
           "style" : "form",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "name",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
           }
         }, {
           "name" : "environment",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1455,8 +1455,7 @@
           "required" : true,
           "style" : "simple",
           "schema" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           }
         } ],
         "responses" : {
@@ -3565,8 +3564,7 @@
             "type" : "string"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "productId" : {
             "type" : "string"
@@ -3724,8 +3722,7 @@
             "type" : "string"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "onboarding" : {
             "type" : "array",
@@ -3842,8 +3839,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "description" : "Institution's type"
           },
           "mailAddress" : {
             "type" : "string",

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -26,10 +26,6 @@
             <version>0.2.1</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-commons</artifactId>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationWithInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationWithInfo.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.model.delegation;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
@@ -19,7 +19,7 @@ public class DelegationWithInfo {
     private DelegationType type;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
-    private InstitutionType institutionType;
+    private String institutionType;
     private String status;
     private String taxCode;
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/Institution.java
@@ -19,7 +19,7 @@ public class Institution {
     private String zipCode;
     private String taxCode;
     private String origin;
-    private InstitutionType institutionType;
+    private String institutionType;
     private List<Attribute> attributes;
     private List<GeographicTaxonomy> geographicTaxonomies;
     private String category;

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/Institution.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/institution/InstitutionInfo.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.util.List;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/InstitutionUpdate.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/InstitutionUpdate.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.rest.model;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.model.institution.AdditionalInformations;
 import it.pagopa.selfcare.dashboard.connector.model.institution.DataProtectionOfficer;
 import it.pagopa.selfcare.dashboard.connector.model.institution.PaymentServiceProvider;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/InstitutionMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/InstitutionMapper.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.dashboard.connector.rest.model.mapper;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.core.generated.openapi.v1.dto.*;
 import it.pagopa.selfcare.dashboard.connector.model.institution.Billing;
 import it.pagopa.selfcare.dashboard.connector.model.institution.*;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingData.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingData.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.dashboard.connector.rest.model.onboarding;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.model.institution.*;
 import it.pagopa.selfcare.dashboard.connector.rest.model.product.ProductInfo;
 import lombok.Data;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingPnPGData.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/onboarding/OnboardingPnPGData.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.dashboard.connector.rest.model.onboarding;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.model.institution.*;
 import it.pagopa.selfcare.dashboard.connector.rest.model.product.PnPGProductInfo;
 import it.pagopa.selfcare.dashboard.connector.rest.model.product.ProductInfo;

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/BrokerServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static it.pagopa.selfcare.commons.base.utils.InstitutionType.PSP;
+import static it.pagopa.selfcare.onboarding.common.InstitutionType.PSP;
 
 
 @Slf4j

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.dashboard.core;
 
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.api.MsCoreConnector;
 import it.pagopa.selfcare.dashboard.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.dashboard.connector.model.delegation.*;

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/DelegationServiceImpl.java
@@ -49,7 +49,7 @@ class DelegationServiceImpl implements DelegationService {
     private void setToInstitutionId(DelegationRequest delegation) {
         List<Institution> institutions = msCoreConnector.getInstitutionsFromTaxCode(delegation.getTo(), null, null, null);
         Institution partner = institutions.stream()
-                .filter(institution -> institution.getInstitutionType() == InstitutionType.PT)
+                .filter(institution -> InstitutionType.PT.name().equals(institution.getInstitutionType()))
                 .findFirst()
                 .orElse(institutions.stream().findFirst()
                         .orElseThrow(() -> new ResourceNotFoundException(

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/SwaggerConfig.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.web.config;
 
 import com.fasterxml.classmate.TypeResolver;
 import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.commons.web.swagger.BaseSwaggerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.*;
@@ -74,6 +75,7 @@ class SwaggerConfig {
                 .directModelSubstitute(LocalTime.class, String.class)
                 .ignoredParameterTypes(Pageable.class)
                 .ignoredParameterTypes(Authentication.class)
+                .ignoredParameterTypes(JwtAuthenticationToken.class)
                 .forCodeGeneration(true)
                 .useDefaultResponseMessages(false)
                 .globalResponses(HttpMethod.GET, List.of(INTERNAL_SERVER_ERROR_RESPONSE, UNAUTHORIZED_RESPONSE, BAD_REQUEST_RESPONSE, NOT_FOUND_RESPONSE))

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/SwaggerConfig.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.*;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.core.Authentication;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.AuthorizationScope;
@@ -72,6 +73,7 @@ class SwaggerConfig {
                         new Tag("onboarding", environment.getProperty("swagger.dashboard.onboarding.api.description")))
                 .directModelSubstitute(LocalTime.class, String.class)
                 .ignoredParameterTypes(Pageable.class)
+                .ignoredParameterTypes(Authentication.class)
                 .forCodeGeneration(true)
                 .useDefaultResponseMessages(false)
                 .globalResponses(HttpMethod.GET, List.of(INTERNAL_SERVER_ERROR_RESPONSE, UNAUTHORIZED_RESPONSE, BAD_REQUEST_RESPONSE, NOT_FOUND_RESPONSE))

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/ProductController.java
@@ -3,7 +3,8 @@ package it.pagopa.selfcare.dashboard.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.dashboard.connector.exception.BadGatewayException;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.dashboard.connector.model.backoffice.BrokerInfo;
 
 import it.pagopa.selfcare.dashboard.core.BrokerService;
@@ -65,15 +66,14 @@ public class ProductController {
                                                         String productId,
                                                         @ApiParam("${swagger.dashboard.products.model.institutionType}")
                                                         @PathVariable("institutionType")
-                                                        InstitutionType institutionType) {
+                                                        String institutionType) {
         log.trace("getProductBrokers start");
         log.debug("productId = {}, institutionType = {}", productId, institutionType);
-        List<BrokerInfo> brokers;
-        if(PAGO_PA_PRODUCT_ID.equals(productId)) {
-            brokers = brokerService.findAllByInstitutionType(institutionType.name());
-        } else {
-            brokers = brokerService.findInstitutionsByProductAndType(productId, institutionType.name());
-        }
+
+        List<BrokerInfo> brokers = PAGO_PA_PRODUCT_ID.equals(productId)
+            ?  brokerService.findAllByInstitutionType(InstitutionType.valueOf(institutionType).name())
+            : brokerService.findInstitutionsByProductAndType(productId, institutionType);
+
         Collection<BrokerResource>  result = brokerResourceMapper.toResourceList(brokers);
         log.debug("getProductBrokers result = {}", result);
         log.trace("getProductBrokers end");

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/InstitutionResource.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.dashboard.web.model;
 
 import io.swagger.annotations.ApiModelProperty;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.util.List;
@@ -22,7 +22,7 @@ public class InstitutionResource {
     private String origin;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.institutionType}")
-    private InstitutionType institutionType;
+    private String institutionType;
 
     @ApiModelProperty(value = "${swagger.dashboard.institutions.model.name}")
     private String name;

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/onboarding/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/onboarding/OnboardingRequestResource.java
@@ -2,7 +2,7 @@ package it.pagopa.selfcare.dashboard.web.model.onboarding;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/ProductControllerTest.java
@@ -147,19 +147,4 @@ class ProductControllerTest extends BaseControllerTest {
         verifyNoMoreInteractions(brokerServiceMock);
     }
 
-
-    @Test
-    void getProductBrokersForUnsupportedType() throws Exception {
-        String productId = "prod-pagopa";
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders
-                        .get(BASE_URL + "/{productId}/brokers/{institutionType}", productId, "TEST")
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .accept(APPLICATION_JSON_VALUE))
-                .andExpect(status().is4xxClientError())
-                .andReturn();
-        // then
-        assertEquals(400, result.getResponse().getStatus());
-        Mockito.verifyNoInteractions(brokerServiceMock);
-    }
-
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Replace it.pagopa.selfcare.commons.base.utils.InstitutionType with it.pagopa.selfcare.onboarding.common.InstitutionType
* Remove some enum InstitutionType with string type
* Upgrade onboarding-sdk with 0.2.1 version

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR replace deprecated commons InstitutionType with onboarding-sdk InstitutionType. In addition, in order to avoid alert on breaking changes OpenAPI we have replaced enum type with less strict string type on InstitutionType responses

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.