### PR TITLE
[SELC-5666] feat: added phasesAdditionAllowed to response on GET /roles

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -3993,6 +3993,13 @@
             "type" : "string",
             "description" : "Party role, available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA"
           },
+          "phasesAdditionAllowed" : {
+            "type" : "array",
+            "description" : "List of phases where addition of the role is allowed",
+            "items" : {
+              "type" : "string"
+            }
+          },
           "productRoles" : {
             "type" : "array",
             "description" : "Available product roles",

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.1</version>
+            <version>0.2.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/product/mapper/ProductMapper.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/product/mapper/ProductMapper.java
@@ -43,16 +43,4 @@ public class ProductMapper {
                 .map(ProductRole::getLabel);
     }
 
-    public static Optional<PartyRole> getPartyRole(String productRoleCode, Map<PartyRole, ProductRoleInfo> roleMappings) {
-        return getPartyRole(productRoleCode, roleMappings, EnumSet.allOf(PartyRole.class));
-    }
-
-    public static Optional<it.pagopa.selfcare.onboarding.common.PartyRole> getPartyRole(String productRoleCode, Map<PartyRole, ProductRoleInfo> roleMappings, EnumSet<PartyRole> partyRoleWhiteList) {
-        return roleMappings.entrySet().stream()
-                .filter(entry -> partyRoleWhiteList.contains(entry.getKey()))
-                .filter(entry -> entry.getValue().getRoles().stream().anyMatch(productRole -> productRole.getCode().equals(productRoleCode)))
-                .map(Map.Entry::getKey)
-                .findAny();
-    }
-
 }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
@@ -13,6 +13,7 @@ import it.pagopa.selfcare.dashboard.connector.model.user.*;
 import it.pagopa.selfcare.dashboard.core.exception.InvalidOnboardingStatusException;
 import it.pagopa.selfcare.dashboard.core.exception.InvalidProductRoleException;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.product.entity.PHASE_ADDITION_ALLOWED;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRole;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
@@ -404,12 +405,24 @@ public class UserV2ServiceImplTest extends BaseServiceTest {
     private static Product getProduct() {
         Product product = new Product();
         Map<PartyRole, it.pagopa.selfcare.product.entity.ProductRoleInfo> map = new EnumMap<>(PartyRole.class);
-        ProductRoleInfo productRoleInfo = new ProductRoleInfo();
+
+        ProductRoleInfo productRoleInfoOperator = new ProductRoleInfo();
+        productRoleInfoOperator.setPhasesAdditionAllowed(List.of(PHASE_ADDITION_ALLOWED.DASHBOARD.value));
         ProductRole productRole = new ProductRole();
         productRole.setCode("operator");
         productRole.setLabel("operator");
-        productRoleInfo.setRoles(List.of(productRole));
-        map.put(PartyRole.OPERATOR, productRoleInfo);
+        productRoleInfoOperator.setRoles(List.of(productRole));
+        map.put(PartyRole.OPERATOR, productRoleInfoOperator);
+
+        ProductRoleInfo productRoleInfoDelegate= new ProductRoleInfo();
+        productRoleInfoDelegate.setPhasesAdditionAllowed(List.of(PHASE_ADDITION_ALLOWED.DASHBOARD.value));
+        ProductRole productRole2 = new ProductRole();
+        productRole2.setCode("delegate");
+        productRole2.setLabel("delegate");
+        productRoleInfoDelegate.setRoles(List.of(productRole2));
+        map.put(PartyRole.DELEGATE, productRoleInfoDelegate);
+
+
         product.setRoleMappings(map);
         return product;
     }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.1</version>
+            <version>0.2.3</version>
             <scope>compile</scope>
         </dependency>
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductsMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductsMapper.java
@@ -7,13 +7,12 @@ import it.pagopa.selfcare.dashboard.web.model.product.ProductRoleMappingsResourc
 import it.pagopa.selfcare.dashboard.web.model.product.ProductsResource;
 import it.pagopa.selfcare.dashboard.web.model.product.SubProductResource;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
-import it.pagopa.selfcare.product.entity.BackOfficeConfigurations;
-import it.pagopa.selfcare.product.entity.Product;
-import it.pagopa.selfcare.product.entity.ProductRole;
-import it.pagopa.selfcare.product.entity.ProductRoleInfo;
+import it.pagopa.selfcare.product.entity.*;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ProductsMapper {
 
@@ -102,6 +101,8 @@ public class ProductsMapper {
             resource.setPartyRole(entry.getKey().name());
             resource.setSelcRole(entry.getKey() != PartyRole.OPERATOR ? SelfCareAuthority.ADMIN : SelfCareAuthority.LIMITED);
             resource.setMultiroleAllowed(entry.getValue().isMultiroleAllowed());
+            resource.setPhasesAdditionAllowed(entry.getValue().getPhasesAdditionAllowed());
+
             if (entry.getValue().getRoles() != null) {
                 resource.setProductRoles(entry.getValue().getRoles().stream()
                         .map(ProductsMapper::toProductRoleResource)

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleMappingsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleMappingsResource.java
@@ -19,6 +19,9 @@ public class ProductRoleMappingsResource {
     @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.multiroleAllowed}")
     private boolean multiroleAllowed;
 
+    @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.phasesAdditionAllowed}")
+    private List<String> phasesAdditionAllowed;
+
     @ApiModelProperty(value = "${swagger.dashboard.product-role-mappings.model.productRoles}")
     private List<ProductRoleResource> productRoles;
 

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -87,6 +87,7 @@ swagger.dashboard.products.model.backOfficeEnvironmentConfigurations=Environment
 swagger.dashboard.product-role-mappings.model.partyRole=Party role, available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA
 swagger.dashboard.product-role-mappings.model.selcRole=Self Care role
 swagger.dashboard.product-role-mappings.model.multiroleAllowed=Indicates if an User can have more than one product role
+swagger.dashboard.product-role-mappings.model.phasesAdditionAllowed=List of phases where addition of the role is allowed
 swagger.dashboard.product-role-mappings.model.productRoles=Available product roles
 swagger.dashboard.product-role.model.code=Product role internal code
 swagger.dashboard.product-role.model.label=Product role label

--- a/web/src/test/resources/json/ProductRoleInfo.json
+++ b/web/src/test/resources/json/ProductRoleInfo.json
@@ -1,5 +1,6 @@
 {
   "multiroleAllowed": true,
+  "phasesAdditionAllowed": ["onboarding","dashboard"],
   "roles": [
     {
       "code": "code1",

--- a/web/src/test/resources/json/ProductRoleMappingsResource.json
+++ b/web/src/test/resources/json/ProductRoleMappingsResource.json
@@ -3,6 +3,7 @@
     "partyRole": "MANAGER",
     "selcRole": "ADMIN",
     "multiroleAllowed": true,
+    "phasesAdditionAllowed": ["onboarding","dashboard"],
     "productRoles": [
       {
         "code": "code1",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added phasesAdditionAllowed to response on GET /roles
* Replace legacy check of validRole with new one retrieving validRole using phasesAdditionAllowed "dashboard"

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to enable addition of roles during added users process using the config property phasesAdditionAllowed. It indicate the phases (onboarding, dashboard, dashboard-async) where adding a Selfcare role is permitted. In bff-dashboard only the roles with "dashboard" phase are permitted. This new logic replace a legacy check based on hardcoded list of [SUB_DELEGATE,OPERATOR]

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.