### PR TITLE
[SELC-5631] feat: add institutionType query param to GET /roles

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1444,6 +1444,15 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "institutionType",
+          "in" : "query",
+          "description" : "Institution's type",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.3</version>
+            <version>0.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/ProductsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/api/ProductsConnector.java
@@ -12,7 +12,7 @@ public interface ProductsConnector {
 
     List<Product> getProducts();
 
-    Map<PartyRole, ProductRoleInfo> getProductRoleMappings(String productId);
+    Map<PartyRole, ProductRoleInfo> getProductRoleMappings(String productId, String institutionType);
 
     Product getProduct(String productId);
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImpl.java
@@ -9,6 +9,7 @@ import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
 import it.pagopa.selfcare.product.service.ProductService;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -36,7 +37,7 @@ public class ProductConnectorImpl implements ProductsConnector {
 
     @Override
     public Map<PartyRole, ProductRoleInfo> getProductRoleMappings(String productId, String institutionType) {
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProduct productId = {}, institutionType = {}", productId, institutionType);
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProduct productId = {}, institutionType = {}", Encode.forJava(productId), Encode.forJava(institutionType));
         Assert.hasText(productId, "A productId is required");
         Product product = productService.getProduct(productId);
         Map<PartyRole, ProductRoleInfo> result = product != null ? product.getRoleMappings(institutionType) : null;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImpl.java
@@ -35,11 +35,11 @@ public class ProductConnectorImpl implements ProductsConnector {
     }
 
     @Override
-    public Map<PartyRole, ProductRoleInfo> getProductRoleMappings(String productId) {
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProduct productId = {}", productId);
+    public Map<PartyRole, ProductRoleInfo> getProductRoleMappings(String productId, String institutionType) {
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProduct productId = {}, institutionType = {}", productId, institutionType);
         Assert.hasText(productId, "A productId is required");
         Product product = productService.getProduct(productId);
-        Map<PartyRole, ProductRoleInfo> result = product != null ? product.getRoleMappings() : null;
+        Map<PartyRole, ProductRoleInfo> result = product != null ? product.getRoleMappings(institutionType) : null;
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProduct result = {}", result);
         return result;
     }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/ProductConnectorImplTest.java
@@ -103,7 +103,7 @@ class ProductConnectorImplTest extends BaseConnectorTest {
     @Test
     void getProductRoleMappingsWithoutProductId() {
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> productConnectorImpl.getProductRoleMappings(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> productConnectorImpl.getProductRoleMappings(null, null));
         verify(productServiceMock, never()).getProduct(null);
     }
 
@@ -111,8 +111,9 @@ class ProductConnectorImplTest extends BaseConnectorTest {
     void getProductRoleMappingsWithEmptyProduct() {
 
         String productId = "123";
+        String institutionType = "type";
         when(productServiceMock.getProduct(productId)).thenReturn(null);
-        Map<PartyRole, ProductRoleInfo> result = productConnectorImpl.getProductRoleMappings(productId);
+        Map<PartyRole, ProductRoleInfo> result = productConnectorImpl.getProductRoleMappings(productId, institutionType);
         assertNull(result);
         Mockito.verify(productServiceMock, times(1)).getProduct(productId);
     }
@@ -121,6 +122,7 @@ class ProductConnectorImplTest extends BaseConnectorTest {
     void testGetProductRoleMappings() throws IOException {
 
         String productId = "123";
+        String institutionType = "type";
 
         ClassPathResource resource = new ClassPathResource("stubs/Product.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
@@ -128,8 +130,8 @@ class ProductConnectorImplTest extends BaseConnectorTest {
         });
 
         when(productServiceMock.getProduct(productId)).thenReturn(product);
-        Map<PartyRole, ProductRoleInfo> result = productConnectorImpl.getProductRoleMappings(productId);
-        Assertions.assertEquals(product.getRoleMappings(), result);
+        Map<PartyRole, ProductRoleInfo> result = productConnectorImpl.getProductRoleMappings(productId, institutionType);
+        Assertions.assertEquals(product.getRoleMappings(institutionType), result);
         Mockito.verify(productServiceMock, times(1)).getProduct(productId);
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductService.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductService.java
@@ -7,6 +7,6 @@ import java.util.Map;
 
 public interface ProductService {
 
-    Map<PartyRole, ProductRoleInfo> getProductRoles(String productId);
+    Map<PartyRole, ProductRoleInfo> getProductRoles(String productId, String institutionType);
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.dashboard.connector.api.ProductsConnector;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -26,7 +27,7 @@ class ProductServiceImpl implements ProductService {
     @Override
     public Map<PartyRole, ProductRoleInfo> getProductRoles(String productId, String institutionType) {
         log.trace("getProductRoles start");
-        log.debug("getProductRoles productId = {}, institutionType = {}", productId, institutionType);
+        log.debug("getProductRoles productId = {}, institutionType = {}", Encode.forJava(productId), Encode.forJava(institutionType));
         Assert.hasText(productId, "A Product id is required");
 
         Map<PartyRole, ProductRoleInfo> productRoleMappings = productsConnector.getProductRoleMappings(productId, institutionType);

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
@@ -24,9 +24,9 @@ class ProductServiceImpl implements ProductService {
 
 
     @Override
-    public Map<PartyRole, ProductRoleInfo> getProductRoles(String productId) {
+    public Map<PartyRole, ProductRoleInfo> getProductRoles(String productId, String institutionType) {
         log.trace("getProductRoles start");
-        log.debug("getProductRoles productId = {}", productId);
+        log.debug("getProductRoles productId = {}, institutionType = {}", productId, institutionType);
         Assert.hasText(productId, "A Product id is required");
 
         Map<PartyRole, ProductRoleInfo> productRoleMappings = productsConnector.getProductRoleMappings(productId);

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/ProductServiceImpl.java
@@ -29,7 +29,7 @@ class ProductServiceImpl implements ProductService {
         log.debug("getProductRoles productId = {}, institutionType = {}", productId, institutionType);
         Assert.hasText(productId, "A Product id is required");
 
-        Map<PartyRole, ProductRoleInfo> productRoleMappings = productsConnector.getProductRoleMappings(productId);
+        Map<PartyRole, ProductRoleInfo> productRoleMappings = productsConnector.getProductRoleMappings(productId, institutionType);
         log.debug("getProductRoles result = {}", productRoleMappings);
         log.trace("getProductRoles end");
         return productRoleMappings;

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
@@ -178,9 +178,11 @@ public class UserV2ServiceImpl implements UserV2Service {
 
             CreateUserDto.Role role = new CreateUserDto.Role();
             role.setProductRole(productRole);
-            role.setLabel(ProductMapper.getLabel(productRole, product.getRoleMappings()).orElse(null));
 
-            List<PartyRole> partyRoles = ProductUtils.validRolesByProductRole(product, PHASE_ADDITION_ALLOWED.DASHBOARD, productRole);
+            //TODO https://pagopa.atlassian.net/browse/SELC-5706 for institutionType=null
+            role.setLabel(ProductMapper.getLabel(productRole, product.getRoleMappings(null)).orElse(null));
+
+            List<PartyRole> partyRoles = ProductUtils.validRolesByProductRole(product, PHASE_ADDITION_ALLOWED.DASHBOARD, productRole, null);
             if(Objects.isNull(partyRoles) || partyRoles.isEmpty()){
                 throw new InvalidProductRoleException(String.format("Product role '%s' is not valid", productRole));
             }

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/ProductServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/ProductServiceImplTest.java
@@ -34,21 +34,22 @@ public class ProductServiceImplTest extends BaseServiceTest {
     void getProductRoles() {
 
         String productId = "productId";
+        String institutionType = "type";
         Map<PartyRole, ProductRoleInfo> productRoleMappingsMock = new HashMap<>();
         ProductRoleInfo productRoleInfo = new ProductRoleInfo();
         productRoleMappingsMock.put(PartyRole.MANAGER, productRoleInfo);
 
-        when(productsConnectorMock.getProductRoleMappings(productId)).thenReturn(productRoleMappingsMock);
+        when(productsConnectorMock.getProductRoleMappings(productId, institutionType)).thenReturn(productRoleMappingsMock);
 
-        Map<PartyRole, ProductRoleInfo> result = productService.getProductRoles(productId);
+        Map<PartyRole, ProductRoleInfo> result = productService.getProductRoles(productId, institutionType);
         Assertions.assertEquals(productRoleMappingsMock, result);
-        Mockito.verify(productsConnectorMock, Mockito.times(1)).getProductRoleMappings(productId);
+        Mockito.verify(productsConnectorMock, Mockito.times(1)).getProductRoleMappings(productId, institutionType);
     }
 
     @Test
     void getProductRolesWithoutProductId() {
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> productService.getProductRoles(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> productService.getProductRoles(null, null));
         Mockito.verifyNoInteractions(productsConnectorMock);
     }
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>compile</scope>
         </dependency>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.3</version>
+            <version>0.3.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/ProductController.java
@@ -47,11 +47,12 @@ public class ProductController {
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.dashboard.product.api.getProductRoles}")
     public Collection<ProductRoleMappingsResource> getProductRoles(@ApiParam("${swagger.dashboard.products.model.id}")
-                                                                   @PathVariable("productId")
-                                                                   String productId) {
+                                                                   @PathVariable("productId") String productId,
+                                                                  @ApiParam("${swagger.dashboard.institutions.model.institutionType}")
+                                                                  @RequestParam(name = "institutionType", required = false) String institutionType) {
         log.trace("getProductRoles start");
         log.debug("productId = {}", productId);
-        Collection<ProductRoleMappingsResource> result = ProductsMapper.toProductRoleMappingsResource(productService.getProductRoles(productId));
+        Collection<ProductRoleMappingsResource> result = ProductsMapper.toProductRoleMappingsResource(productService.getProductRoles(productId, institutionType));
         log.debug("getProductRoles result = {}", result);
         log.trace("getProductRoles end");
 

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/ProductControllerTest.java
@@ -55,16 +55,18 @@ class ProductControllerTest extends BaseControllerTest {
     void getProductRoles() throws Exception {
         // given
         String productId = "prod1";
+        String institutionType = "type";
         byte[] productRoleInfoStream = Files.readAllBytes(Paths.get(FILE_JSON_PATH + "ProductRoleInfo.json"));
         ProductRoleInfo productRoleInfo = objectMapper.readValue(productRoleInfoStream, ProductRoleInfo.class);
 
-        when(productServiceMock.getProductRoles(productId))
+        when(productServiceMock.getProductRoles(productId, institutionType))
                 .thenReturn(new EnumMap<>(PartyRole.class) {{
                     put(PartyRole.MANAGER, productRoleInfo);
                 }});
         // when
         mockMvc.perform(MockMvcRequestBuilders
                         .get(BASE_URL + "/{productId}/roles", productId)
+                        .queryParam("institutionType", institutionType)
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
@@ -72,7 +74,7 @@ class ProductControllerTest extends BaseControllerTest {
                 .andReturn();
         // then
         verify(productServiceMock, times(1))
-                .getProductRoles(productId);
+                .getProductRoles(productId, institutionType);
         verifyNoMoreInteractions(productServiceMock);
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* add institutionType query param to GET /roles
* retrieve roles using getRoleMappings(institutionType)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to retrieve roleMappings also using institutionType in "Utenti" section. It is needed when a product have different roles based on institutionType, for ex. for prod-pagopa

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.