### PR TITLE
[SELC-6020] feat: map selcRole ADMIN_EA in getProductRoles API

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationWithInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/delegation/DelegationWithInfo.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.dashboard.connector.model.delegation;
 
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductsMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductsMapper.java
@@ -7,14 +7,20 @@ import it.pagopa.selfcare.dashboard.web.model.product.ProductRoleMappingsResourc
 import it.pagopa.selfcare.dashboard.web.model.product.ProductsResource;
 import it.pagopa.selfcare.dashboard.web.model.product.SubProductResource;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
-import it.pagopa.selfcare.product.entity.*;
+import it.pagopa.selfcare.product.entity.BackOfficeConfigurations;
+import it.pagopa.selfcare.product.entity.Product;
+import it.pagopa.selfcare.product.entity.ProductRole;
+import it.pagopa.selfcare.product.entity.ProductRoleInfo;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ProductsMapper {
+
+    static final Map<PartyRole, SelfCareAuthority> ROLE_MAP = Map.of(
+            PartyRole.OPERATOR, SelfCareAuthority.LIMITED,
+            PartyRole.ADMIN_EA, SelfCareAuthority.ADMIN_EA
+    );
 
     public static ProductsResource toResource(ProductTree model) {
         ProductsResource resource = null;
@@ -99,7 +105,7 @@ public class ProductsMapper {
         if (entry != null) {
             resource = new ProductRoleMappingsResource();
             resource.setPartyRole(entry.getKey().name());
-            resource.setSelcRole(entry.getKey() != PartyRole.OPERATOR ? SelfCareAuthority.ADMIN : SelfCareAuthority.LIMITED);
+            resource.setSelcRole(toSelcRole(entry.getKey()));
             resource.setMultiroleAllowed(entry.getValue().isMultiroleAllowed());
             resource.setPhasesAdditionAllowed(entry.getValue().getPhasesAdditionAllowed());
 
@@ -122,6 +128,10 @@ public class ProductsMapper {
             resource.setDescription(productRole.getDescription());
         }
         return resource;
+    }
+
+    static SelfCareAuthority toSelcRole(PartyRole partyRole) {
+        return ROLE_MAP.getOrDefault(partyRole, SelfCareAuthority.ADMIN);
     }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductMapperTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/model/mapper/ProductMapperTest.java
@@ -108,7 +108,7 @@ class ProductMapperTest {
     @Test
     void toProductRoleMappingsResource_fromEntry_nullRoles() {
         // given
-        Map.Entry<PartyRole, ProductRoleInfo> input = Map.entry(PartyRole.DELEGATE, mockInstance(new ProductRoleInfo()));
+        Map.Entry<PartyRole, ProductRoleInfo> input = Map.entry(PartyRole.OPERATOR, mockInstance(new ProductRoleInfo()));
         // when
         ProductRoleMappingsResource output = ProductsMapper.toProductRoleMappingsResource(input);
         // then
@@ -118,7 +118,7 @@ class ProductMapperTest {
 
 
     @Test
-    void toProductRoleMappingsResource_fromEntry_notNull() {
+    void toProductRoleMappingsResource_fromEntry_notNull_ADMIN() {
         // given
         ProductRoleInfo productRoleInfo = mockInstance(new ProductRoleInfo(), "setRoles");
         productRoleInfo.setRoles(List.of(mockInstance(new ProductRole())));
@@ -131,6 +131,23 @@ class ProductMapperTest {
         assertEquals(productRoleInfo.getRoles().size(), output.getProductRoles().size());
         assertEquals(input.getKey().name(), output.getPartyRole());
         assertEquals(SelfCareAuthority.ADMIN, output.getSelcRole());
+        assertEquals(input.getValue().isMultiroleAllowed(), output.isMultiroleAllowed());
+    }
+
+    @Test
+    void toProductRoleMappingsResource_fromEntry_notNull_ADMIN_EA() {
+        // given
+        ProductRoleInfo productRoleInfo = mockInstance(new ProductRoleInfo(), "setRoles");
+        productRoleInfo.setRoles(List.of(mockInstance(new ProductRole())));
+        Map.Entry<PartyRole, ProductRoleInfo> input = Map.entry(PartyRole.ADMIN_EA, productRoleInfo);
+        // when
+        ProductRoleMappingsResource output = ProductsMapper.toProductRoleMappingsResource(input);
+        // then
+        assertNotNull(output);
+        assertNotNull(output.getProductRoles());
+        assertEquals(productRoleInfo.getRoles().size(), output.getProductRoles().size());
+        assertEquals(input.getKey().name(), output.getPartyRole());
+        assertEquals(SelfCareAuthority.ADMIN_EA, output.getSelcRole());
         assertEquals(input.getValue().isMultiroleAllowed(), output.isMultiroleAllowed());
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- map selcRole ADMIN_EA in getProductRoles API

<!--- Describe your changes in detail -->

#### Motivation and Context
This change ensures that the getProductRoles API response includes the selcRole value ADMIN_EA. This allows the frontend to implement the logic needed to display the appropriate label associated with this role.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.