### PR TITLE
[SELC-6055] feat: add fiscalCode and createdAt fields in getUsers API and add roles filter

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -3938,7 +3938,7 @@
           },
           "selcRole" : {
             "type" : "string",
-            "description" : "User's role, available value: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]",
+            "description" : "User's Selfcare role, available value: [ADMIN, ADMIN_EA, LIMITED]",
             "enum" : [ "ADMIN", "ADMIN_EA", "LIMITED" ]
           },
           "status" : {
@@ -4031,7 +4031,7 @@
           },
           "role" : {
             "type" : "string",
-            "description" : "User's role, available value: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]",
+            "description" : "User's Selfcare role, available value: [ADMIN, ADMIN_EA, LIMITED]",
             "enum" : [ "ADMIN", "ADMIN_EA", "LIMITED" ]
           },
           "status" : {

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -4003,9 +4003,18 @@
         "title" : "ProductUserResource",
         "type" : "object",
         "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "description" : "User's creation date associated with a product",
+            "format" : "date-time"
+          },
           "email" : {
             "type" : "string",
             "description" : "User's personal email"
+          },
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "User's fiscal code"
           },
           "id" : {
             "type" : "string",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2466,6 +2466,16 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "roles",
+          "in" : "query",
+          "description" : "roles",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/user/ProductInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/user/ProductInfo.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.dashboard.connector.model.user;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -10,5 +11,6 @@ public class ProductInfo {
     private String id;
     private String title;
     private List<RoleInfo> roleInfos;
+    private LocalDateTime createdAt;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/user/UserInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/dashboard/connector/model/user/UserInfo.java
@@ -5,7 +5,8 @@ import it.pagopa.selfcare.dashboard.connector.model.institution.RelationshipStat
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(of = "id")
@@ -24,6 +25,7 @@ public class UserInfo {
         private SelfCareAuthority role;
         private String productId;
         private List<String> productRoles;
+        private List<String> roles;
         private String userId;
         private List<RelationshipState> allowedStates;
     }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -177,12 +177,11 @@ public class UserConnectorImpl implements UserApiConnector {
 
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
 
-        List<String> roles = userInfoFilter.getRoles() == null ?
+        List<String> roles = Optional.ofNullable(userInfoFilter.getRoles()).orElse(
                 Arrays.stream(PartyRole.values())
-                .filter(partyRole -> partyRole.getSelfCareAuthority().equals(userInfoFilter.getRole()))
-                .map(Enum::name)
-                .toList()
-                : userInfoFilter.getRoles();
+                        .filter(partyRole -> partyRole.getSelfCareAuthority().equals(userInfoFilter.getRole()))
+                        .map(Enum::name)
+                        .toList());
 
         return Optional.ofNullable(userApiRestClient._retrieveUsers(institutionId,
                                 loggedUserId,

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -177,10 +177,12 @@ public class UserConnectorImpl implements UserApiConnector {
 
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
 
-        List<String> roles = Arrays.stream(PartyRole.values())
+        List<String> roles = userInfoFilter.getRoles() == null ?
+                Arrays.stream(PartyRole.values())
                 .filter(partyRole -> partyRole.getSelfCareAuthority().equals(userInfoFilter.getRole()))
                 .map(Enum::name)
-                .toList();
+                .toList()
+                : userInfoFilter.getRoles();
 
         return Optional.ofNullable(userApiRestClient._retrieveUsers(institutionId,
                                 loggedUserId,

--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/UserMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/model/mapper/UserMapper.java
@@ -3,7 +3,6 @@ package it.pagopa.selfcare.dashboard.connector.rest.model.mapper;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
 import it.pagopa.selfcare.dashboard.connector.model.user.*;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.*;
-import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserInstitutionWithActions;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -92,6 +91,7 @@ public interface UserMapper {
                 onboardedProducts.forEach(onboardedProduct -> {
                     RoleInfo roleInfo = new RoleInfo();
                     productInfo.setId(onboardedProduct.getProductId());
+                    productInfo.setCreatedAt(onboardedProduct.getCreatedAt());
                     roleInfo.setRole(onboardedProduct.getProductRole());
                     roleInfo.setStatus(onboardedProduct.getStatus().name());
                     roleInfo.setSelcRole(it.pagopa.selfcare.commons.base.security.PartyRole.valueOf(onboardedProduct.getRole()).getSelfCareAuthority());

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2Service.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2Service.java
@@ -1,7 +1,10 @@
 package it.pagopa.selfcare.dashboard.core;
 
 import it.pagopa.selfcare.dashboard.connector.model.institution.InstitutionBase;
-import it.pagopa.selfcare.dashboard.connector.model.user.*;
+import it.pagopa.selfcare.dashboard.connector.model.user.UpdateUserRequestDto;
+import it.pagopa.selfcare.dashboard.connector.model.user.User;
+import it.pagopa.selfcare.dashboard.connector.model.user.UserInfo;
+import it.pagopa.selfcare.dashboard.connector.model.user.UserToCreate;
 
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +26,7 @@ public interface UserV2Service {
 
     void updateUser(String id, String institutionId, UpdateUserRequestDto userDto);
 
-    Collection<UserInfo> getUsersByInstitutionId(String institutionId, String productId, List<String> productRoles, String loggedUserId);
+    Collection<UserInfo> getUsersByInstitutionId(String institutionId, String productId, List<String> productRoles, List<String> roles , String loggedUserId);
 
     String createUsers(String institutionId, String productId, UserToCreate userToCreate);
 

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImpl.java
@@ -117,13 +117,14 @@ public class UserV2ServiceImpl implements UserV2Service {
     }
 
     @Override
-    public Collection<UserInfo> getUsersByInstitutionId(String institutionId, String productId, List<String> productRoles, String loggedUserId) {
+    public Collection<UserInfo> getUsersByInstitutionId(String institutionId, String productId, List<String> productRoles, List<String> roles, String loggedUserId) {
         log.trace("getUsersByInstitutionId start");
         log.debug("getUsersByInstitutionId institutionId = {}", institutionId);
         UserInfo.UserInfoFilter userInfoFilter = new UserInfo.UserInfoFilter();
         userInfoFilter.setProductId(productId);
         userInfoFilter.setProductRoles(productRoles);
         userInfoFilter.setAllowedStates(allowedStates);
+        userInfoFilter.setRoles(roles);
         Collection<UserInfo> result = userApiConnector.getUsers(institutionId, userInfoFilter, loggedUserId);
         log.info("getUsersByInstitutionId result size = {}", result.size());
         log.trace("getUsersByInstitutionId end");

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/UserV2ServiceImplTest.java
@@ -152,7 +152,7 @@ public class UserV2ServiceImplTest extends BaseServiceTest {
         List<String> productRoles = new ArrayList<>();
         String loggedUserId = "loggedUserId";
 
-        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, loggedUserId);
+        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, null, loggedUserId);
         Assertions.assertTrue(result.isEmpty());
     }
 
@@ -171,7 +171,7 @@ public class UserV2ServiceImplTest extends BaseServiceTest {
 
         when(userApiConnectorMock.getUsers(institutionId, userInfoFilter, loggedUserId)).thenReturn(new ArrayList<>());
 
-        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, loggedUserId);
+        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, null, loggedUserId);
         Assertions.assertTrue(result.isEmpty());
     }
 
@@ -195,7 +195,7 @@ public class UserV2ServiceImplTest extends BaseServiceTest {
 
         when(userApiConnectorMock.getUsers(institutionId, userInfoFilter, loggedUserId)).thenReturn(userInfo);
 
-        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, loggedUserId);
+        Collection<UserInfo> result = userV2ServiceImpl.getUsersByInstitutionId(institutionId, productId, productRoles, null, loggedUserId);
         Assertions.assertEquals(userInfo, result);
         Mockito.verify(userApiConnectorMock, Mockito.times(1)).getUsers(institutionId, userInfoFilter, loggedUserId);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <description>Self Care Dashboard Backend</description>
 
     <properties>
-        <selc-commons.version>2.5.3</selc-commons.version>
+        <selc-commons.version>2.5.4</selc-commons.version>
         <sonar.host.url>https://sonarcloud.io/</sonar.host.url>
     </properties>
 

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/UserV2Controller.java
@@ -163,13 +163,14 @@ public class UserV2Controller {
                                               @PathVariable("institutionId") String institutionId,
                                               @RequestParam(value = "productId", required = false) String productId,
                                               @RequestParam(value = "productRoles", required = false) List<String> productRoles,
+                                              @RequestParam(value = "roles", required = false) List<String> roles,
                                               Authentication authentication) {
         log.trace("getUsers start");
         log.debug("getUsers for institution: {} and product: {}", institutionId, productId);
         String loggedUserId = ((SelfCareUser) authentication.getPrincipal()).getId();
 
         List<ProductUserResource> response = new ArrayList<>();
-        Collection<UserInfo> userInfos = userService.getUsersByInstitutionId(institutionId, productId, productRoles, loggedUserId);
+        Collection<UserInfo> userInfos = userService.getUsersByInstitutionId(institutionId, productId, productRoles, roles, loggedUserId);
         userInfos.forEach(userInfo -> response.addAll(UserMapper.toProductUsers(userInfo)));
         log.debug("getUsers result = {}", response);
         log.trace("getUsers end");

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/UserMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/mapper/UserMapper.java
@@ -154,6 +154,7 @@ public class UserMapper {
                 if (model.getUser() != null) {
                     resource.setName(CertifiedFieldMapper.toValue(model.getUser().getName()));
                     resource.setSurname(CertifiedFieldMapper.toValue(model.getUser().getFamilyName()));
+                    resource.setFiscalCode(model.getUser().getFiscalCode());
                     Optional.ofNullable(model.getUser().getWorkContacts())
                             .map(map -> map.get(model.getUserMailUuid()))
                             .map(WorkContact::getEmail)
@@ -161,6 +162,7 @@ public class UserMapper {
                             .ifPresent(resource::setEmail);
                 }
                 resource.setProduct(UserMapper.toUserProductInfoResource(productInfo));
+                resource.setCreatedAt(productInfo.getCreatedAt());
                 response.add(resource);
             });
         }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleInfoResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductRoleInfoResource.java
@@ -13,7 +13,7 @@ public class ProductRoleInfoResource {
     private String role;
     @ApiModelProperty(value = "${swagger.dashboard.user.model.status}")
     private String status;
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}")
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.selcRole}")
     private SelfCareAuthority selcRole;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
@@ -37,7 +37,7 @@ public class ProductUserResource {
     @ApiModelProperty(value = "${swagger.dashboard.user.model.email}")
     private String email;
 
-    @ApiModelProperty(value = "${swagger.dashboard.user.model.role}")
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.selcRole}")
     private SelfCareAuthority role;
 
     @ApiModelProperty(value = "${swagger.dashboard.user.model.product}")

--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/model/product/ProductUserResource.java
@@ -16,6 +16,7 @@ import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -30,6 +31,9 @@ public class ProductUserResource {
     @ApiModelProperty(value = "${swagger.dashboard.user.model.surname}")
     private String surname;
 
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.fiscalCode}")
+    private String fiscalCode;
+
     @ApiModelProperty(value = "${swagger.dashboard.user.model.email}")
     private String email;
 
@@ -41,6 +45,9 @@ public class ProductUserResource {
 
     @ApiModelProperty(value = "${swagger.dashboard.user.model.status}")
     private String status;
+
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.createdAt}")
+    private LocalDateTime createdAt;
 
 
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -104,6 +104,7 @@ swagger.dashboard.user.model.email=User's personal email
 swagger.dashboard.user.model.workContacts=User's workcontacts, contains the emails associated to every institution the user is assigned to
 swagger.dashboard.user.model.institutionalEmail=User's institutional email
 swagger.dashboard.user.model.role=User's role, available value: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]
+swagger.dashboard.user.model.selcRole=User's Selfcare role, available value: [ADMIN, ADMIN_EA, LIMITED]
 swagger.dashboard.user.model.fields=Fields to retrieve from pdv when searching for user
 swagger.dashboard.user.model.createdAt=User's creation date associated with a product
 swagger.dashboard.products.model.roleInfos=User's role infos in product

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -105,6 +105,7 @@ swagger.dashboard.user.model.workContacts=User's workcontacts, contains the emai
 swagger.dashboard.user.model.institutionalEmail=User's institutional email
 swagger.dashboard.user.model.role=User's role, available value: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]
 swagger.dashboard.user.model.fields=Fields to retrieve from pdv when searching for user
+swagger.dashboard.user.model.createdAt=User's creation date associated with a product
 swagger.dashboard.products.model.roleInfos=User's role infos in product
 swagger.dashboard.user.model.productRoles=User's roles in product
 swagger.dashboard.user.model.productRole=User's role in product

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/UserV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/UserV2ControllerTest.java
@@ -9,6 +9,7 @@ import it.pagopa.selfcare.dashboard.web.model.SearchUserDto;
 import it.pagopa.selfcare.dashboard.web.model.UpdateUserDto;
 import it.pagopa.selfcare.dashboard.web.model.mapper.UserMapperV2Impl;
 import it.pagopa.selfcare.dashboard.web.model.user.UserResource;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -223,13 +224,14 @@ class UserV2ControllerTest extends BaseControllerTest {
         UserInfo userInfo = objectMapper.readValue(userInfoStream, UserInfo.class);
         List<UserInfo> userInfos = List.of(userInfo);
 
-        when(userServiceMock.getUsersByInstitutionId(institutionId, productId, null, "userId")).thenReturn(userInfos);
+        when(userServiceMock.getUsersByInstitutionId(institutionId, productId, null, List.of(PartyRole.MANAGER.name()), "userId")).thenReturn(userInfos);
 
         // when
         mockMvc.perform(MockMvcRequestBuilders
                         .get(BASE_URL + "/institution/" + institutionId)
                         .principal(authentication)
                         .queryParam("productId", productId)
+                        .queryParam("roles", PartyRole.MANAGER.name())
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
@@ -237,7 +239,7 @@ class UserV2ControllerTest extends BaseControllerTest {
 
         // then
         verify(userServiceMock, times(1))
-                .getUsersByInstitutionId(institutionId, productId, null, "userId");
+                .getUsersByInstitutionId(institutionId, productId, null, List.of(PartyRole.MANAGER.name()), "userId");
         verifyNoMoreInteractions(userServiceMock);
     }
 
@@ -397,7 +399,7 @@ class UserV2ControllerTest extends BaseControllerTest {
         when(authentication.getPrincipal()).thenReturn(SelfCareUser.builder("userId").build());
 
         // when
-        when(userServiceMock.getUsersByInstitutionId(institutionId, productId, null, "userId"))
+        when(userServiceMock.getUsersByInstitutionId(institutionId, productId, null, null, "userId"))
                 .thenReturn(List.of(new UserInfo()));
 
         // when
@@ -412,7 +414,7 @@ class UserV2ControllerTest extends BaseControllerTest {
 
         // then
         verify(userServiceMock, times(1))
-                .getUsersByInstitutionId(institutionId, productId, null, "userId");
+                .getUsersByInstitutionId(institutionId, productId, null, null, "userId");
         verifyNoMoreInteractions(userServiceMock);
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add fiscalCode in getUsers API response
- add createdAt in getUsers API response
- add roles optional filter in getUsers API
- align unit tests
- align openapi
- upgrade commons version to 2.5.4

<!--- Describe your changes in detail -->

#### Motivation and Context
This update enables the frontend to retrieve information about the Legale Rappresentante during the administration adding flow. Specifically, it allows the frontend to pre-fill the related fields (name, surname, fiscal code, and email) with the corresponding data for a better user experience.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.