### PR TITLE
[SELC-6461] fix: roles and status params can be null in getUserCount

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2Controller.java
@@ -109,7 +109,9 @@ public class InstitutionV2Controller {
                                           @ApiParam(value = "${swagger.dashboard.user.model.statusList}")
                                           @RequestParam(name = "status", required = false) String[] status) {
         log.trace("getUserCount start");
-        UserCount userCount = userService.getUserCount(institutionId, productId, Arrays.asList(roles), Arrays.asList(status));
+        UserCount userCount = userService.getUserCount(institutionId, productId,
+                Optional.ofNullable(roles).map(Arrays::asList).orElse(Collections.emptyList()),
+                Optional.ofNullable(status).map(Arrays::asList).orElse(Collections.emptyList()));
         UserCountResource result = userMapperV2.toUserCountResource(userCount);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getUserCount result = {}", result);
         log.trace("getUserCount end");

--- a/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/dashboard/web/controller/InstitutionV2ControllerTest.java
@@ -509,6 +509,39 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
         verifyNoMoreInteractions(userServiceMock);
     }
 
+    @Test
+    void getUserCountWithNullRolesAndStatus() throws Exception {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        final UserCount userCount = new UserCount();
+        userCount.setInstitutionId(institutionId);
+        userCount.setProductId(productId);
+        userCount.setRoles(Arrays.asList("defaultRole1", "defaultRole2"));
+        userCount.setStatus(Arrays.asList("defaultStatus1", "defaultStatus2"));
+        userCount.setCount(2L);
+        when(userServiceMock.getUserCount(institutionId, productId, Collections.emptyList(), Collections.emptyList())).thenReturn(userCount);
+
+        final MvcResult result = mockMvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/{institutionId}/products/{productId}/users/count", institutionId, productId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        UserCountResource resource = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        assertEquals(userCount.getInstitutionId(), resource.getInstitutionId());
+        assertEquals(userCount.getProductId(), resource.getProductId());
+        assertIterableEquals(userCount.getRoles(), resource.getRoles());
+        assertIterableEquals(userCount.getStatus(), resource.getStatus());
+        assertEquals(userCount.getCount(), resource.getCount());
+
+        verify(userServiceMock, times(1))
+                .getUserCount(institutionId, productId, Collections.emptyList(), Collections.emptyList());
+        verifyNoMoreInteractions(userServiceMock);
+    }
+
     private DelegationWithInfo dummyDelegation() {
         DelegationWithInfo delegation = new DelegationWithInfo();
         delegation.setInstitutionId("from");


### PR DESCRIPTION
#### List of Changes

- Handling null roles and status params in getUserCount

#### Motivation and Context

getUserCount does not handle null roles and status parameters

#### How Has This Been Tested?

- Local tests
- Unit tests

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.