### PR TITLE
[SELC-6476] feat: changed how the name field in jwt token of support service is valued

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -9,12 +9,16 @@ import it.pagopa.selfcare.dashboard.connector.model.support.SupportRequest;
 import it.pagopa.selfcare.dashboard.connector.model.support.SupportResponse;
 import it.pagopa.selfcare.dashboard.connector.model.support.UserField;
 import it.pagopa.selfcare.dashboard.connector.model.user.User;
+import it.pagopa.selfcare.dashboard.core.utils.EmailUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.UUID;
 
 import static it.pagopa.selfcare.dashboard.connector.model.user.User.Fields.*;
 
@@ -47,7 +51,7 @@ public class SupportServiceImpl implements SupportService {
         log.trace("sendRequest start");
         log.debug("sendRequest request = {}", supportRequest);
 
-        supportRequest.setName(getNameFromMail(supportRequest.getEmail()));
+        supportRequest.setName(EmailUtils.getUsername(supportRequest.getEmail()));
         if(StringUtils.hasText(supportRequest.getUserId())) {
             try {
                 User user = userRegistryConnector.getUserByInternalId(supportRequest.getUserId(), USER_FIELD_LIST);
@@ -100,14 +104,6 @@ public class SupportServiceImpl implements SupportService {
                     : "?institution=" + supportRequest.getInstitutionId());
         }
         return urlBuilder.toString();
-    }
-
-    private String getNameFromMail(String email) {
-        return Optional.ofNullable(email)
-                .map(m -> m.indexOf("@"))
-                .filter(i -> i > -1)
-                .map(i -> email.substring(0, i))
-                .orElse(email);
     }
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/SupportServiceImpl.java
@@ -14,10 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 import static it.pagopa.selfcare.dashboard.connector.model.user.User.Fields.*;
 
@@ -50,10 +47,10 @@ public class SupportServiceImpl implements SupportService {
         log.trace("sendRequest start");
         log.debug("sendRequest request = {}", supportRequest);
 
+        supportRequest.setName(getNameFromMail(supportRequest.getEmail()));
         if(StringUtils.hasText(supportRequest.getUserId())) {
             try {
                 User user = userRegistryConnector.getUserByInternalId(supportRequest.getUserId(), USER_FIELD_LIST);
-                supportRequest.setName(user.getName().getValue().concat(" " + user.getFamilyName().getValue()));
                 supportRequest.setUserFields(UserField.builder().aux_data(user.getFiscalCode()).build());
             } catch (Exception e) {
                 throw new ResourceNotFoundException("User with id " + supportRequest.getUserId() + " not found");
@@ -104,4 +101,13 @@ public class SupportServiceImpl implements SupportService {
         }
         return urlBuilder.toString();
     }
+
+    private String getNameFromMail(String email) {
+        return Optional.ofNullable(email)
+                .map(m -> m.indexOf("@"))
+                .filter(i -> i > -1)
+                .map(i -> email.substring(0, i))
+                .orElse(email);
+    }
+
 }

--- a/core/src/main/java/it/pagopa/selfcare/dashboard/core/utils/EmailUtils.java
+++ b/core/src/main/java/it/pagopa/selfcare/dashboard/core/utils/EmailUtils.java
@@ -1,0 +1,27 @@
+package it.pagopa.selfcare.dashboard.core.utils;
+
+import java.util.Optional;
+
+public class EmailUtils {
+
+    private EmailUtils() {}
+
+    /**
+     * <p>Extract the first part of an email address before the at symbol (aka username)</p>
+     * <ul>
+     * <li>If the email address is null, return null</li>
+     * <li>if the email address doesn't contain the at symbol return the string itself</li>
+     * </ul>
+     *
+     * @param email the email address string
+     * @return the username
+     */
+    public static String getUsername(String email) {
+        return Optional.ofNullable(email)
+                .map(m -> m.indexOf("@"))
+                .filter(i -> i > -1)
+                .map(i -> email.substring(0, i))
+                .orElse(email);
+    }
+
+}

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/SupportServiceImplTest.java
@@ -71,9 +71,78 @@ public class SupportServiceImplTest extends BaseServiceTest {
         Assertions.assertEquals(expectation.getRedirectUrl(), response.getRedirectUrl());
         Assertions.assertEquals(expectation.getActionUrl(), response.getActionUrl());
 
-        final String jwtBody = Jwts.parser().setSigningKey(supportApiKey.getBytes()).parse(response.getJwt()).toString();
+        final String jwtBody = Jwts.parser().setSigningKey(supportApiKey.getBytes())
+                .parseClaimsJws(response.getJwt()).getBody().toString();
         Assertions.assertTrue(jwtBody.contains("name=example"));
         Assertions.assertTrue(jwtBody.contains("email=example@example.com"));
+        Assertions.assertTrue(jwtBody.contains("organization=testZendeskOrganization"));
+        Assertions.assertTrue(jwtBody.contains("user_fields={aux_data=NLLGPJ67L30L783W}"));
+
+        Mockito.verify(userRegistryConnectorMock, Mockito.times(1)).getUserByInternalId(supportRequest.getUserId(), USER_FIELD_LIST);
+    }
+
+    @Test
+    void sendRequestWithEmptySupportRequest() {
+        final String supportApiKey = "testSupportApiKey";
+        ReflectionTestUtils.setField(supportServiceImpl, "supportApiKey", supportApiKey);
+        ReflectionTestUtils.setField(supportServiceImpl, "returnTo", "testReturnTo");
+        ReflectionTestUtils.setField(supportServiceImpl, "zendeskOrganization", "testZendeskOrganization");
+        ReflectionTestUtils.setField(supportServiceImpl, "actionUrl", "testActionUrl");
+
+        SupportResponse expectation = new SupportResponse();
+        expectation.setRedirectUrl("testReturnTo");
+        expectation.setActionUrl("testActionUrl");
+
+        SupportResponse response = supportServiceImpl.sendRequest(new SupportRequest());
+
+        Assertions.assertEquals(expectation.getRedirectUrl(), response.getRedirectUrl());
+        Assertions.assertEquals(expectation.getActionUrl(), response.getActionUrl());
+
+        final String jwtBody = Jwts.parser().setSigningKey(supportApiKey.getBytes())
+                .parseClaimsJws(response.getJwt()).getBody().toString();
+        Assertions.assertFalse(jwtBody.contains("name"));
+        Assertions.assertFalse(jwtBody.contains("email"));
+        Assertions.assertTrue(jwtBody.contains("organization=testZendeskOrganization"));
+        Assertions.assertFalse(jwtBody.contains("user_fields"));
+
+        Mockito.verifyNoInteractions(userRegistryConnectorMock);
+    }
+
+    @Test
+    void sendRequestWithoutAtSymbolInMail() throws IOException {
+        final String supportApiKey = "testSupportApiKey";
+        ReflectionTestUtils.setField(supportServiceImpl, "supportApiKey", supportApiKey);
+        ReflectionTestUtils.setField(supportServiceImpl, "returnTo", "testReturnTo");
+        ReflectionTestUtils.setField(supportServiceImpl, "zendeskOrganization", "testZendeskOrganization");
+        ReflectionTestUtils.setField(supportServiceImpl, "actionUrl", "testActionUrl");
+
+        SupportResponse expectation = new SupportResponse();
+        expectation.setRedirectUrl("testReturnTo?product=productId&institution=institutionId");
+        expectation.setActionUrl("testActionUrl");
+
+
+        ClassPathResource resource = new ClassPathResource("expectations/SupportRequest.json");
+        byte[] supportRequestStream = Files.readAllBytes(resource.getFile().toPath());
+        SupportRequest supportRequest = objectMapper.readValue(supportRequestStream, new TypeReference<>() {
+        });
+        supportRequest.setEmail("test");
+
+        ClassPathResource userResource = new ClassPathResource("expectations/User.json");
+        byte[] userStream = Files.readAllBytes(userResource.getFile().toPath());
+        User user = objectMapper.readValue(userStream, new TypeReference<>() {
+        });
+
+        when(userRegistryConnectorMock.getUserByInternalId(supportRequest.getUserId(), USER_FIELD_LIST)).thenReturn(user);
+
+        SupportResponse response = supportServiceImpl.sendRequest(supportRequest);
+
+        Assertions.assertEquals(expectation.getRedirectUrl(), response.getRedirectUrl());
+        Assertions.assertEquals(expectation.getActionUrl(), response.getActionUrl());
+
+        final String jwtBody = Jwts.parser().setSigningKey(supportApiKey.getBytes())
+                .parseClaimsJws(response.getJwt()).getBody().toString();
+        Assertions.assertTrue(jwtBody.contains("name=test"));
+        Assertions.assertTrue(jwtBody.contains("email=test"));
         Assertions.assertTrue(jwtBody.contains("organization=testZendeskOrganization"));
         Assertions.assertTrue(jwtBody.contains("user_fields={aux_data=NLLGPJ67L30L783W}"));
 

--- a/core/src/test/java/it/pagopa/selfcare/dashboard/core/utils/EmailUtilsTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/dashboard/core/utils/EmailUtilsTest.java
@@ -1,0 +1,18 @@
+package it.pagopa.selfcare.dashboard.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class EmailUtilsTest {
+
+    @Test
+    void getUsernameTest() {
+        assertEquals("test", EmailUtils.getUsername("test@test.com"));
+        assertEquals("test", EmailUtils.getUsername("test"));
+        assertEquals("", EmailUtils.getUsername("@test.com"));
+        assertNull(EmailUtils.getUsername(null));
+    }
+
+}


### PR DESCRIPTION
#### List of Changes

- Added new function to get the name from the email field

#### Motivation and Context

Help support team better organize tickets via email instead of using first name + last name

#### How Has This Been Tested?

- Local tests
- Unit tests

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.