### PR TITLE
[SELC-6512] fix: handling ResourceNotFoundException returned by user-ms with an empty list in GET /v2/institutions

### DIFF
--- a/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImpl.java
@@ -43,8 +43,15 @@ public class UserConnectorImpl implements UserApiConnector {
     @Retry(name = "retryTimeout")
     public List<InstitutionBase> getUserInstitutions(String userId) {
         log.trace("getUserProducts start");
-        UserInfoResponse userInfoResponse = userApiRestClient._getUserProductsInfo(userId, null,
-                List.of(ACTIVE.name(), PENDING.name(), TOBEVALIDATED.name())).getBody();
+
+        UserInfoResponse userInfoResponse;
+        try {
+            userInfoResponse = userApiRestClient._getUserProductsInfo(userId, null,
+                    List.of(ACTIVE.name(), PENDING.name(), TOBEVALIDATED.name())).getBody();
+        } catch (ResourceNotFoundException ex) {
+            log.debug("getUserProducts - User with id {} not found", userId);
+            return List.of();
+        }
 
         if(Objects.isNull(userInfoResponse) ||
                 Objects.isNull(userInfoResponse.getInstitutions())) return List.of();

--- a/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/dashboard/connector/rest/UserConnectorImplTest.java
@@ -73,7 +73,8 @@ class UserConnectorImplTest extends BaseConnectorTest {
         String userId = "userId";
         when(userApiRestClient._getUserProductsInfo(userId, null,
                 List.of(ACTIVE.name(), PENDING.name(), TOBEVALIDATED.name()))).thenThrow(ResourceNotFoundException.class);
-        Assertions.assertThrows(ResourceNotFoundException.class, () -> userConnector.getUserInstitutions(userId));
+        final List<InstitutionBase> userInstitutions = userConnector.getUserInstitutions(userId);
+        Assertions.assertTrue(userInstitutions.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
#### List of Changes

- Added a catch ResourceNotFoundException in UserConnectorImpl -> getUserInstitutions(String userId)

#### Motivation and Context

The FE expects an empty list in case there are no userInstitutions associated to a userId

#### How Has This Been Tested?

- Local tests
- Unit tests

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.