### PR TITLE
Removed spring-boot-starter-data-mongodb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,11 +144,6 @@
             <artifactId>spring-boot-starter-freemarker</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/it/pagopa/selfcare/dashboard/integration_test/steps/UserApiSteps.java
+++ b/src/test/java/it/pagopa/selfcare/dashboard/integration_test/steps/UserApiSteps.java
@@ -19,9 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import static com.mongodb.assertions.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UserApiSteps{
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,5 +1,0 @@
-user-group.allowed.sorting.parameters=name
-spring.data.mongodb.uri=mongodb://localhost:27017
-spring.data.mongodb.database=selcUserGroup
-rest-assured.base-url=http://localhost
-rest-assured.port=8080


### PR DESCRIPTION
#### List of Changes

- Removed dependency spring-boot-starter-data-mongodb
- Using spring-data-commons

#### Motivation and Context

The dashboard doesn't need to connect to any Mongo database. The presence of this dependency triggers a health check that verifies whether a connection to a Mongo database has been established, blocking the deploy of the application.

#### How Has This Been Tested?

- deploy tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.