### PR TITLE
[SELC-7475] Created getMyUserGroupById + Removed institutionId parameter from getUserGroupById

### DIFF
--- a/src/main/java/it/pagopa/selfcare/dashboard/controller/UserGroupV2Controller.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/controller/UserGroupV2Controller.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.dashboard.controller;
 
 import io.swagger.annotations.*;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.web.model.Page;
 import it.pagopa.selfcare.commons.web.model.mapper.PageMapper;
 import it.pagopa.selfcare.dashboard.model.groups.CreateUserGroup;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -125,18 +127,32 @@ public class UserGroupV2Controller {
     @ApiOperation(value = "", notes = "${swagger.dashboard.user-group.api.getUserGroup}")
     @PreAuthorize("hasPermission(new it.pagopa.selfcare.dashboard.security.FilterAuthorityDomain(null, null, #id), 'Selc:ManageProductGroups')")
     public UserGroupResource getUserGroupById(@ApiParam("${swagger.dashboard.user-group.model.id}")
-                                              @PathVariable("id") String id,
-                                              @ApiParam("${swagger.dashboard.user-group.model.institutionId}")
-                                              @RequestParam(value = "institutionId", required = false) String institutionId) {
+                                              @PathVariable("id") String id) {
         log.trace("getUserGroup start");
-        log.debug("getUserGroup id = {}, institutionId = {}", id, institutionId);
-        UserGroupInfo groupInfo = groupService.getUserGroupById(id, institutionId);
+        log.debug("getUserGroup id = {}", id);
+        UserGroupInfo groupInfo = groupService.getUserGroupById(id);
         UserGroupResource groupResource = groupMapper.toResource(groupInfo,userMapper);
         log.debug("getUserGroup result = {}", groupResource);
         log.trace("getUserGroup end");
         return groupResource;
     }
 
+    @GetMapping(value = "/me/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.dashboard.user-group.api.getUserGroup}")
+    @PreAuthorize("hasPermission(new it.pagopa.selfcare.dashboard.security.FilterAuthorityDomain(null, null, #id), 'Selc:ListProductGroups')")
+    public UserGroupResource getMyUserGroupById(@ApiParam("${swagger.dashboard.user-group.model.id}")
+                                                @PathVariable("id") String id,
+                                                Authentication authentication) {
+        log.trace("getMyUserGroupById start");
+        SelfCareUser user = (SelfCareUser) authentication.getPrincipal();
+        log.debug("getMyUserGroupById id = {}, memberId = {}", id, user.getId());
+        UserGroupInfo groupInfo = groupService.getUserGroupById(id, user.getId());
+        UserGroupResource groupResource = groupMapper.toResource(groupInfo,userMapper);
+        log.debug("getMyUserGroupById result = {}", groupResource);
+        log.trace("getMyUserGroupById end");
+        return groupResource;
+    }
 
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/it/pagopa/selfcare/dashboard/service/UserGroupV2Service.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/service/UserGroupV2Service.java
@@ -26,7 +26,9 @@ public interface UserGroupV2Service {
 
     void deleteMemberFromUserGroup(String groupId, UUID userId);
 
-    UserGroupInfo getUserGroupById(String groupId, String institutionId);
+    UserGroupInfo getUserGroupById(String groupId);
+
+    UserGroupInfo getUserGroupById(String groupId, String memberId);
 
     Page<UserGroup> getUserGroups(String institutionId, String productId, UUID userId, Pageable pageable);
 }

--- a/src/main/resources/swagger/api-docs.json
+++ b/src/main/resources/swagger/api-docs.json
@@ -2338,6 +2338,79 @@
         } ]
       }
     },
+    "/v2/user-groups/me/{id}" : {
+      "get" : {
+        "tags" : [ "user-groups" ],
+        "summary" : "getMyUserGroupById",
+        "description" : "Service to get a specific UserGroup entity",
+        "operationId" : "getMyUserGroupByIdUsingGET",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "Users group's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroupResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/user-groups/{id}" : {
       "get" : {
         "tags" : [ "user-groups" ],
@@ -2350,15 +2423,6 @@
           "description" : "Users group's unique identifier",
           "required" : true,
           "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Users group's institutionId",
-          "required" : false,
-          "style" : "form",
           "schema" : {
             "type" : "string"
           }

--- a/src/test/resources/features/UserGroup.feature
+++ b/src/test/resources/features/UserGroup.feature
@@ -200,20 +200,12 @@ Feature: UserGroups
     When I send a GET request to "/v2/user-groups/{id}" to retrieve userGroup
     Then the response status should be 404
 
-  Scenario: Attempt to retrieve a group with a valid ID with valid institutionId filter
+  Scenario: Attempt to retrieve a group with a valid ID
     Given user login with username "j.doe" and password "test"
     And I have groupId "6759f8df78b6af202b222d29"
-    And the institutionId is "c9a50656-f345-4c81-84be-5b2474470544"
     When I send a GET request to "/v2/user-groups/{id}" to retrieve userGroup
     Then the response status should be 200
     And the response should contain the group details
-
-  Scenario: Attempt to retrieve a group with a valid ID with invalid institutionId filter
-    Given user login with username "j.doe" and password "test"
-    And I have groupId "6759f8df78b6af202b222d29"
-    And the institutionId is "467ac77d-7faa-47bf-a60e-38ea74bd5fd2"
-    When I send a GET request to "/v2/user-groups/{id}" to retrieve userGroup
-    Then the response status should be 404
 
   Scenario: Successfully retrieve user groups with valid filters
     Given user login with username "j.doe" and password "test"


### PR DESCRIPTION
#### List of Changes

- Created getMyUserGroupById to allows users with action ListProductGroups to retrieve only the groups they are part of
- Removed parameter institutionId from getUserGroupById and using the relative field saved at db

#### Motivation and Context

Allow users with the ManageProductGroups action to get all groups, even if they are not part of that group, while limiting group retrieval for users with only the ListProductGroups action

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.