### PR TITLE
[SELC-7327] feat: add field toAddOnAggregates to addUserProductRoles and createInstitutionProductUser api

### DIFF
--- a/docs/openapi/selfcare-user-docs.json
+++ b/docs/openapi/selfcare-user-docs.json
@@ -1817,6 +1817,9 @@
           },
           "delegationId" : {
             "type" : "string"
+          },
+          "toAddOnAggregates" : {
+            "type" : "boolean"
           }
         }
       },
@@ -1840,6 +1843,9 @@
             "items" : {
               "type" : "string"
             }
+          },
+          "toAddOnAggregates" : {
+            "type" : "boolean"
           }
         }
       },

--- a/integration-test-config/mock/user-registry-api.json
+++ b/integration-test-config/mock/user-registry-api.json
@@ -398,6 +398,27 @@
       "path": "/user-registry-mock/v1/users/search",
       "queryStringParameters": {
         "fl": [
+          "fiscalCode,familyName,email,name,workContacts"
+        ]
+      },
+      "body": {
+        "type": "JSON",
+        "json": {
+          "fiscalCode": "blbrki80A41H401T"
+        },
+        "matchType": "STRICT"
+      }
+    },
+    "httpResponseTemplate": {
+      "templateType": "VELOCITY",
+      "template": "{\"statusCode\":200,\"body\":{\"id\":\"35a78332-d038-4bfa-8e85-2cba7f6b7bf7\",\"fiscalCode\":\"blbrki80A41H401T\",\"name\":{\"certification\":\"SPID\",\"value\":\"rocky\"},\"familyName\":{\"certification\":\"SPID\",\"value\":\"Balboa\"},\"email\":{\"certification\":\"SPID\",\"value\":\"personal@test.it\"},\"workContacts\":{\"ID_MAIL#9425e6ea-7d84-4c5e-9196-6f66b62800b2\":{\"email\":{\"certification\":\"NONE\",\"value\":\"r.balboa@regionelazio.it\"}},\"ID_MAIL#123123-55555-efaz-12312-apclacpela\":{\"email\":{\"certification\":\"NONE\",\"value\":\"r.balboa@unibologna.it\"}},\"ID_CONTACTS#35a78332-d038-4bfa-8e85-2cba7f6b7bf7\":{\"email\":{\"certification\":\"NONE\",\"value\":\"8370aa38-a2ab-404b-9b8a-10487167332e@test.it\"},\"mobilePhone\":{\"certification\":\"NONE\",\"value\":\"3365252525\"}}}}}"    }
+  },
+  {
+    "httpRequest": {
+      "method": "POST",
+      "path": "/user-registry-mock/v1/users/search",
+      "queryStringParameters": {
+        "fl": [
           {
             "schema": {
               "type": "string",
@@ -451,6 +472,38 @@
     "httpResponseTemplate": {
       "templateType": "VELOCITY",
       "template": "{\"statusCode\":200,\"body\":{\"id\":\"97a511a7-2acc-47b9-afed-2f3c65753b4a\"}}"
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "PATCH",
+      "path": "/user-registry-mock/v1/users",
+      "body": {
+        "type": "JSON",
+        "json": {
+          "fiscalCode": "blbrki80A41H401T"
+        },
+        "matchType": "ONLY_MATCHING_FIELDS"
+      }
+    },
+    "httpResponseTemplate": {
+      "templateType": "VELOCITY",
+      "template": "{\"statusCode\":200,\"body\":{\"id\":\"35a78332-d038-4bfa-8e85-2cba7f6b7bf7\"}}"
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "PATCH",
+      "path": "/user-registry-mock/v1/users/{id}",
+      "pathParameters": {
+        "id": [
+          "35a78332-d038-4bfa-8e85-2cba7f6b7bf7"
+        ]
+      }
+    },
+    "httpResponseTemplate": {
+      "templateType": "VELOCITY",
+      "template": "{\"statusCode\":204}"
     }
   },
   {

--- a/src/main/java/it/pagopa/selfcare/dashboard/controller/InstitutionV2Controller.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/controller/InstitutionV2Controller.java
@@ -144,7 +144,7 @@ public class InstitutionV2Controller {
                                     UserProductRoles userProductRoles) {
         log.trace("addUserProductRoles start");
         log.debug("institutionId = {}, productId = {}, userId = {}, userProductRoles = {}", institutionId, productId, userId, userProductRoles);
-        userService.addUserProductRoles(institutionId, productId, userId, userProductRoles.getProductRoles(), userProductRoles.getRole());
+        userService.addUserProductRoles(institutionId, productId, userId, userProductRoles.getToAddOnAggregates(), userProductRoles.getProductRoles(), userProductRoles.getRole());
         log.trace("addUserProductRoles end");
     }
 

--- a/src/main/java/it/pagopa/selfcare/dashboard/model/CreateUserDto.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/model/CreateUserDto.java
@@ -35,4 +35,7 @@ public class CreateUserDto {
     @NotEmpty
     private Set<String> productRoles;
 
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.toAddOnAggregates}")
+    private Boolean toAddOnAggregates;
+
 }

--- a/src/main/java/it/pagopa/selfcare/dashboard/model/user/UserProductRoles.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/model/user/UserProductRoles.java
@@ -14,4 +14,7 @@ public class UserProductRoles {
 
     @NotEmpty
     Set<String> productRoles;
+
+    @ApiModelProperty(value = "${swagger.dashboard.user.model.toAddOnAggregates}")
+    private Boolean toAddOnAggregates;
 }

--- a/src/main/java/it/pagopa/selfcare/dashboard/model/user/UserToCreate.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/model/user/UserToCreate.java
@@ -13,4 +13,5 @@ public class UserToCreate {
     private String email;
     private PartyRole role;
     private Set<String> productRoles;
+    private Boolean toAddOnAggregates;
 }

--- a/src/main/java/it/pagopa/selfcare/dashboard/service/UserV2Service.java
+++ b/src/main/java/it/pagopa/selfcare/dashboard/service/UserV2Service.java
@@ -31,7 +31,7 @@ public interface UserV2Service {
 
     String createUsers(String institutionId, String productId, UserToCreate userToCreate);
 
-    void addUserProductRoles(String institutionId, String productId, String userId, Set<String> productRoles, String role);
+    void addUserProductRoles(String institutionId, String productId, String userId, Boolean toAddOnAggregates, Set<String> productRoles, String role);
 
     UsersCountResponse getUserCount(String institutionId, String productId, List<String> roles, List<String> status);
 

--- a/src/main/resources/swagger/api-docs.json
+++ b/src/main/resources/swagger/api-docs.json
@@ -3691,6 +3691,11 @@
           "taxCode" : {
             "type" : "string",
             "description" : "User's fiscal code"
+          },
+          "toAddOnAggregates" : {
+            "type" : "boolean",
+            "description" : "Enable automatic management of group assignment",
+            "example" : false
           }
         }
       },
@@ -5102,6 +5107,11 @@
           "role" : {
             "type" : "string",
             "description" : "User's role, available values: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]"
+          },
+          "toAddOnAggregates" : {
+            "type" : "boolean",
+            "description" : "Enable automatic management of group assignment",
+            "example" : false
           }
         }
       },

--- a/src/main/resources/swagger/swagger_en.properties
+++ b/src/main/resources/swagger/swagger_en.properties
@@ -121,6 +121,7 @@ swagger.dashboard.user.model.fields=Fields to retrieve from pdv when searching f
 swagger.dashboard.user.model.createdAt=User's creation date associated with a product
 swagger.dashboard.products.model.roleInfos=User's role infos in product
 swagger.dashboard.user.model.productRoles=User's roles in product
+swagger.dashboard.user.model.toAddOnAggregates=Enable automatic management of group assignment
 swagger.dashboard.user.model.productRole=User's role in product
 swagger.dashboard.user.model.products=Authorized user products
 swagger.dashboard.user.model.product=Authorized user product

--- a/src/test/java/it/pagopa/selfcare/dashboard/controller/InstitutionV2ControllerTest.java
+++ b/src/test/java/it/pagopa/selfcare/dashboard/controller/InstitutionV2ControllerTest.java
@@ -196,6 +196,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
         final String userId = "userId";
         UserProductRoles userProductRoles = new UserProductRoles();
         userProductRoles.setProductRoles(Set.of("admin"));
+        userProductRoles.setToAddOnAggregates(true);
 
         Authentication authentication = mock(Authentication.class);
 
@@ -211,7 +212,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
 
         // then
         verify(userServiceMock, times(1))
-                .addUserProductRoles(institutionId, productId, userId, userProductRoles.getProductRoles(), userProductRoles.getRole());
+                .addUserProductRoles(institutionId, productId, userId, userProductRoles.getToAddOnAggregates(), userProductRoles.getProductRoles(), userProductRoles.getRole());
         verifyNoMoreInteractions(userServiceMock);
     }
 
@@ -225,6 +226,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
         UserProductRoles userProductRoles = new UserProductRoles();
         userProductRoles.setProductRoles(Set.of("admin"));
         userProductRoles.setRole("MANAGER");
+        userProductRoles.setToAddOnAggregates(true);
 
         Authentication authentication = mock(Authentication.class);
 
@@ -240,7 +242,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
 
         // then
         verify(userServiceMock, times(1))
-                .addUserProductRoles(institutionId, productId, userId, userProductRoles.getProductRoles(), userProductRoles.getRole());
+                .addUserProductRoles(institutionId, productId, userId, userProductRoles.getToAddOnAggregates(), userProductRoles.getProductRoles(), userProductRoles.getRole());
         verifyNoMoreInteractions(userServiceMock);
     }
 
@@ -278,6 +280,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
         createUserDto.setTaxCode("ABC123");
         createUserDto.setEmail("john.doe@example.com");
         createUserDto.setProductRoles(Set.of("admin"));
+        createUserDto.setToAddOnAggregates(true);
 
         UserToCreate userToCreate = userMapper.toUserToCreate(createUserDto);
 
@@ -314,6 +317,7 @@ class InstitutionV2ControllerTest extends BaseControllerTest {
         createUserDto.setEmail("john.doe@example.com");
         createUserDto.setProductRoles(Set.of("admin"));
         createUserDto.setRole("MANAGER");
+        createUserDto.setToAddOnAggregates(true);
 
         UserToCreate userToCreate = userMapper.toUserToCreate(createUserDto);
 

--- a/src/test/java/it/pagopa/selfcare/dashboard/integration_test/steps/DashboardStepsUtil.java
+++ b/src/test/java/it/pagopa/selfcare/dashboard/integration_test/steps/DashboardStepsUtil.java
@@ -249,6 +249,7 @@ public class DashboardStepsUtil {
         createUserDto.setEmail(entry.get("email"));
         createUserDto.setRole(entry.get("role"));
         createUserDto.setProductRoles(mapProductRoles(entry.get("productRoles")));
+        createUserDto.setToAddOnAggregates(Boolean.valueOf(entry.get("toAddOnAggregates")));
 
         return createUserDto;
     }
@@ -258,6 +259,7 @@ public class DashboardStepsUtil {
 
         createUserDto.setRole(entry.get("role"));
         createUserDto.setProductRoles(mapProductRoles(entry.get("productRoles")));
+        createUserDto.setToAddOnAggregates(Boolean.valueOf(entry.get("toAddOnAggregates")));
 
         return createUserDto;
     }

--- a/src/test/java/it/pagopa/selfcare/dashboard/service/UserV2ServiceImplTest.java
+++ b/src/test/java/it/pagopa/selfcare/dashboard/service/UserV2ServiceImplTest.java
@@ -311,6 +311,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String userId = "userId";
         Set<String> productRoles = new HashSet<>(List.of("operator"));
         String role = "OPERATOR";
+        Boolean toAddOnAggregates = true;
         Product product = getProduct();
 
         Institution institution = new Institution();
@@ -340,7 +341,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         when(coreInstitutionApiRestClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institutionMock));
         when(productService.getProduct(productId)).thenReturn(product);
 
-        userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, role);
+        userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, role);
 
         verify(userApiRestClient, times(1))._createOrUpdateByUserId(anyString(), any());
         verifyNoMoreInteractions(userApiRestClient);
@@ -352,6 +353,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String productId = "productId";
         final String userId = "userId";
         Set<String> productRoles = new HashSet<>(List.of("operator"));
+        Boolean toAddOnAggregates = true;
         Product product = getProduct();
 
         Institution institution = new Institution();
@@ -381,7 +383,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         when(coreInstitutionApiRestClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institutionMock));
         when(productService.getProduct(productId)).thenReturn(product);
 
-        userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, OPERATOR.name());
+        userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, OPERATOR.name());
 
         verify(userApiRestClient, times(1))._createOrUpdateByUserId(anyString(), any());
         verifyNoMoreInteractions(userApiRestClient);
@@ -394,13 +396,14 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String userId = "userId";
         Set<String> productRoles = new HashSet<>(List.of("operator"));
         String role = "MANAGER";
+        Boolean toAddOnAggregates = true;
 
         InstitutionResponse institution = new InstitutionResponse();
         institution.setId(institutionId);
 
         when(coreInstitutionApiRestClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institution));
 
-        Assertions.assertThrows(InvalidOnboardingStatusException.class, () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, role));
+        Assertions.assertThrows(InvalidOnboardingStatusException.class, () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, role));
 
         verifyNoInteractions(userApiRestClient);
     }
@@ -411,6 +414,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String productId = "productId";
         final String userId = "userId";
         final Set<String> productRoles = Set.of("operator");
+        Boolean toAddOnAggregates = true;
         final Product product = getProduct();
 
         final InstitutionResponse institution = new InstitutionResponse();
@@ -424,11 +428,11 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         when(productService.getProduct(productId)).thenReturn(product);
 
         assertThrows(InvalidProductRoleException.class,
-                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, null),
+                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, null),
                 "The product doesn't allow adding users directly with these role and productRoles");
 
         assertThrows(InvalidProductRoleException.class,
-                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, "MANAGER"),
+                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, "MANAGER"),
                 "The product doesn't allow adding users directly with these role and productRoles");
     }
 
@@ -439,6 +443,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String userId = "userId";
         final Set<String> productRoles = Set.of("manager");
         final String role = "MANAGER";
+        Boolean toAddOnAggregates = true;
 
         final Product product = getProduct();
         final ProductRoleInfo productRoleInfoManager = new ProductRoleInfo();
@@ -460,7 +465,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         when(productService.getProduct(productId)).thenReturn(product);
 
         assertThrows(InvalidProductRoleException.class,
-                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, role),
+                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, role),
                 "The product doesn't allow adding users directly with these role and productRoles");
     }
 
@@ -471,6 +476,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final String userId = "userId";
         final Set<String> productRoles = Set.of("operator2", "operator0", "operator1");
         final String role = "OPERATOR";
+        Boolean toAddOnAggregates = true;
 
         final Product product = getProduct();
         final ProductRoleInfo productRoleInfoOperator = getProductRoleInfo();
@@ -487,7 +493,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         when(productService.getProduct(productId)).thenReturn(product);
 
         assertThrows(InvalidProductRoleException.class,
-                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, productRoles, role),
+                () -> userV2ServiceImpl.addUserProductRoles(institutionId, productId, userId, toAddOnAggregates, productRoles, role),
                 "The product doesn't allow adding users directly with these role and productRoles");
     }
 
@@ -514,6 +520,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         productRoles.add(productRole);
         userToCreate.setRole(OPERATOR);
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         Product product = getProduct();
 
@@ -559,6 +566,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         productRoles.add(productRole);
         userToCreate.setRole(OPERATOR);
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         Product product = getProduct();
 
@@ -603,6 +611,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         HashSet<String> productRoles = new HashSet<>();
         productRoles.add("operator");
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         InstitutionResponse institutionMock = new InstitutionResponse();
         institutionMock.setId(institutionId);
@@ -623,6 +632,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final Set<String> productRoles = Set.of("manager");
         userToCreate.setRole(MANAGER);
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         final Product product = getProduct();
 
@@ -649,6 +659,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final Set<String> productRoles = Set.of("manager");
         userToCreate.setRole(MANAGER);
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         final Product product = getProduct();
         final ProductRoleInfo productRoleInfoManager = new ProductRoleInfo();
@@ -682,6 +693,7 @@ class UserV2ServiceImplTest extends BaseServiceTest {
         final Set<String> productRoles = Set.of("operator2", "operator0", "operator1");
         userToCreate.setRole(OPERATOR);
         userToCreate.setProductRoles(productRoles);
+        userToCreate.setToAddOnAggregates(true);
 
         final Product product = getProduct();
         final ProductRoleInfo productRoleInfoOperator = new ProductRoleInfo();

--- a/src/test/resources/features/Institution.feature
+++ b/src/test/resources/features/Institution.feature
@@ -176,6 +176,16 @@ Feature: Institution
     Then the response status should be 200
     And the response should contain an empty institutions list
 
+  Scenario: Successfully create user product by a user by institutionId
+    Given user login with username "j.doe" and password "test"
+    And the institutionId is "c9a50656-f345-4c81-84be-5b2474470544"
+    And the productId is "prod-pagopa"
+    And the following user data request details:
+      | name  | surname | taxCode          | email      | role     | productRoles | toAddOnAggregates |
+      | Rocky | Balboa  | blbrki80A41H401T | rb@test.it | OPERATOR | operator     | true              |
+    When I send a POST request to "/v2/institutions/{institutionId}/products/{productId}/users" to create a new user related to a product for institutions
+    Then the response status should be 201
+
   Scenario: Attempt to create user product by a user by institutionId and with an existent different role
     Given user login with username "j.doe" and password "test"
     And the institutionId is "067327d3-bdd6-408d-8655-87e8f1960046"
@@ -244,15 +254,15 @@ Feature: Institution
     And the productId is "prod-interop"
     And the userId is "35a78332-d038-4bfa-8e85-2cba7f6b7bf7"
     And the following user product request details:
-      | role     | productRoles |
-      | OPERATOR | security     |
+      | role     | productRoles | toAddOnAggregates |
+      | OPERATOR | security     | true              |
     When I send a PUT request to "/v2/institutions/{institutionId}/products/{productId}/users/{userId}" to add a new user related to a product for institutions
     Then the response status should be 201
     And I send a GET request to "/v2/institutions/{institutionId}/users/{userId}" to retrieve institution user
     Then the response status should be 200
     And The response body contains:
       | id         | 35a78332-d038-4bfa-8e85-2cba7f6b7bf7 |
-    And The response body contains the list "products" of size 2
+    And The response body contains the list "products" of size 3
 
   Scenario: Attempt to add user by institutionId, productId and userId without permission
     Given user login with username "j.doe" and password "test"
@@ -318,7 +328,7 @@ Feature: Institution
     When I send a GET request to "/v2/institutions/{institutionId}/products/{productId}/users/count" to get users count
     Then the response status should be 200
     And The response body contains:
-      | count | 2 |
+      | count | 3 |
 
   Scenario: Attempt to get User Count without permission (OPERATOR)
     Given user login with username "j.doe" and password "test"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- add cucumber test
- add field toAddOnAggregates to UserProductRoles in addUserProductRoles  api
- add field toAddOnAggregates to CreateUserDto in createInstitutionProductUser api
- update unit test 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Guarantee automatic management of group assignment when adding new Operator users

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.